### PR TITLE
fix the -showBuildSettings parse error

### DIFF
--- a/main.go
+++ b/main.go
@@ -303,14 +303,6 @@ func parseShowBuildSettingsOutput(out string) (serialized.Object, error) {
 
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
-		if strings.HasPrefix(line, "Build settings") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "User defaults from command line") {
-			continue
-		}
-
 		if line == "" {
 			continue
 		}
@@ -318,7 +310,7 @@ func parseShowBuildSettingsOutput(out string) (serialized.Object, error) {
 		split := strings.Split(line, " = ")
 
 		if len(split) < 2 {
-			return nil, fmt.Errorf("unknown build settings: %s", line)
+			continue
 		}
 
 		key := strings.TrimSpace(split[0])


### PR DESCRIPTION
Fix the "Failed to parse build settings, error: unknown build settings" error which caused if the output contained a line without a `=` (no key - value pair)