### PR TITLE
Revamp input structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_tmp/
 .bitrise*
 .gows.user.yml
 .idea/

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bitrise-io/go-steputils v0.0.0-20210924114124-851d30b88892
 	github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d
-	github.com/bitrise-io/go-xcode v0.0.0-20210927150020-dd11ae1c9008
+	github.com/bitrise-io/go-xcode v0.0.0-20210928140350-ec12eb8661c0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d h1:jU5wvShTLKS
 github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/go-xcode v0.0.0-20210927150020-dd11ae1c9008 h1:9Pn7LCh/W3WnqJ4G3UGJCOn8cYwJELzygZvMR2Zwsow=
 github.com/bitrise-io/go-xcode v0.0.0-20210927150020-dd11ae1c9008/go.mod h1:R+mDPZyTUBfd/wpN8bl67BYsDaCTgS6FDwBSZG4UmGA=
+github.com/bitrise-io/go-xcode v0.0.0-20210928140350-ec12eb8661c0 h1:gihGjCEtxIM/i0v8jCfRLn6sUG0lBaJ+EBzrdInRXX8=
+github.com/bitrise-io/go-xcode v0.0.0-20210928140350-ec12eb8661c0/go.mod h1:R+mDPZyTUBfd/wpN8bl67BYsDaCTgS6FDwBSZG4UmGA=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-const xcodebuildLogPath = "BITRISE_XCODEBUILD_LOG_PATH"
+const xcodebuildLogPath = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
 
 // Config ...
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-const bitriseXcodeRawResultTextEnvKey = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
+const xcodebuildLogPath = "BITRISE_XCODEBUILD_LOG_PATH"
 
 // Config ...
 type Config struct {
@@ -173,13 +173,10 @@ func main() {
 	// save the build time frame to find the build generated artifacts
 	rawXcodebuildOut, buildInterval, xcodebuildErr := runCommandWithRetry(xcodeBuildCmd, cfg.LogFormatter == "xcpretty", swiftPackagesPath)
 
-	if err := output.ExportOutputFileContent(rawXcodebuildOut, rawXcodebuildOutputLogPath, bitriseXcodeRawResultTextEnvKey); err != nil {
-		log.Warnf("Failed to export %s, error: %s", bitriseXcodeRawResultTextEnvKey, err)
-	} else {
-		log.Warnf(`You can find the last couple of lines of Xcode's build log above, but the full log is also available in the %s
-The log file is stored in $BITRISE_DEPLOY_DIR, and its full path is available in the $%s environment variable
-(value: %s)`, filepath.Base(rawXcodebuildOutputLogPath), bitriseXcodeRawResultTextEnvKey, rawXcodebuildOutputLogPath)
+	if err := output.ExportOutputFileContent(rawXcodebuildOut, rawXcodebuildOutputLogPath, xcodebuildLogPath); err != nil {
+		log.Warnf("Failed to export %s, error: %s", xcodebuildLogPath, err)
 	}
+	log.Donef("The xcodebuild command log file path is available in BITRISE_XCODEBUILD_LOG_PATH env: %s", rawXcodebuildOutputLogPath)
 
 	if xcodebuildErr != nil {
 		if cfg.LogFormatter == "xcpretty" {

--- a/main.go
+++ b/main.go
@@ -171,8 +171,6 @@ func main() {
 	xcodeBuildCmd.SetXCConfigPath(xcconfigPath)
 
 	// save the build time frame to find the build generated artifacts
-	var buildInterval timeInterval
-
 	rawXcodebuildOut, buildInterval, xcodebuildErr := runCommandWithRetry(xcodeBuildCmd, cfg.LogFormatter == "xcpretty", swiftPackagesPath)
 
 	if err := output.ExportOutputFileContent(rawXcodebuildOut, rawXcodebuildOutputLogPath, bitriseXcodeRawResultTextEnvKey); err != nil {

--- a/main.go
+++ b/main.go
@@ -214,7 +214,6 @@ The log file is stored in $BITRISE_DEPLOY_DIR, and its full path is available in
 	cmd := factory.Create(args[0], args[1:], nil)
 	fmt.Println()
 	log.Donef("$ %s", cmd.PrintableCommandArgs())
-	fmt.Println()
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		failf("%s failed, error: %s", cmd.PrintableCommandArgs(), err)
@@ -230,11 +229,13 @@ The log file is stored in $BITRISE_DEPLOY_DIR, and its full path is available in
 	if err != nil {
 		failf("Failed to parse SYMROOT build setting: %s", err)
 	}
+	log.Printf("SYMROOT: %s", symRoot)
 
 	configuration, err := buildSettings.String("CONFIGURATION")
 	if err != nil {
 		failf("Failed to parse CONFIGURATION build setting: %s", err)
 	}
+	log.Printf("CONFIGURATION: %s", configuration)
 
 	// Without better solution the step collects every xctestrun files and filters them for the build time frame
 	xctestrunPthPattern := filepath.Join(symRoot, fmt.Sprintf("%s*.xctestrun", cfg.Scheme))
@@ -242,6 +243,7 @@ The log file is stored in $BITRISE_DEPLOY_DIR, and its full path is available in
 	if err != nil {
 		failf("Failed to search for xctestrun file using pattern: %s, error: %s", xctestrunPthPattern, err)
 	}
+	log.Printf("xctestrun paths: %s", strings.Join(xctestrunPths, ", "))
 
 	if len(xctestrunPths) == 0 {
 		failf("No xctestrun file found with pattern: %s", xctestrunPthPattern)

--- a/step.yml
+++ b/step.yml
@@ -201,9 +201,8 @@ outputs:
   - BITRISE_TEST_BUNDLE_ZIP_PATH:
     opts:
       title: "The built test directory and the built xctestrun file compressed as a single zip"
-  - BITRISE_XCODE_BUILD_RAW_RESULT_TEXT_PATH:
+  - BITRISE_XCODEBUILD_LOG_PATH:
     opts:
-      title: The full, raw build output file path
+      title: xcodebuild command log file path
       description: |-
-        This is the path of the raw build results log file.
-        If `output_tool=xcpretty` and the build fails this log will contain the build output.
+        The step exports the `xcodebuild build-for-testing` command output log.

--- a/step.yml
+++ b/step.yml
@@ -59,102 +59,127 @@ toolkit:
 inputs:
   - project_path: $BITRISE_PROJECT_PATH
     opts:
-      title: Project (or Workspace) path
-      summary: "A `.xcodeproj` or `.xcworkspace` path."
-      description: "A `.xcodeproj` or `.xcworkspace` path."
+      title: Project path
+      summary: Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
+      description: |-
+        Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
+
+        The input value sets xcodebuild's `-project` or `-workspace` option.
       is_required: true
+
   - scheme: $BITRISE_SCHEME
     opts:
-      title: Scheme name
-      summary: "The Scheme to use."
-      description: "The Scheme to use."
-      is_required: true
-  - configuration: Debug
-    opts:
-      title: "Configuration name"
+      title: Scheme
+      summary: Xcode Scheme name.
       description: |-
-        (optional) The configuration to use. By default your Scheme
-        defines which configuration (Debug, Release, ...) should be used,
-        but you can overwrite it with this option.
-        **Make sure that the Configuration you specify actually exists
-        in your Xcode Project**. If it does not, if you have a typo
-        in the value of this input Xcode will simply use the Configuration
-        specified by the Scheme and will silently ignore this parameter!
+        Xcode Scheme name.
+
+        The input value sets xcodebuild's `-scheme` option.
+      is_required: true
+
+  - configuration:
+    opts:
+      title: Build Configuration
+      summary: Xcode Build Configuration.
+      description: |-
+        Xcode Build Configuration.
+
+        If not specified, the default Build Configuration will be used.
+
+        The input value sets xcodebuild's `-configuration` option.
+
   - destination: generic/platform=iOS
     opts:
-      title: Device destination
+      title: Device destination specifier
+      summary: Destination specifier describes the device to use as a destination.
       description: |-
-        Specify destination to build the testes for.
-        For available values call: `man xcodebuild` and check the _Destinations_ section.
+        Destination specifier describes the device to use as a destination.
+
+        The input value sets xcodebuild's `-destination` option.
       is_required: true
-  - disable_index_while_building: "yes"
+
+  # xcodebuild configuration
+
+  - xcconfig_content: "COMPILER_INDEX_STORE_ENABLE = NO"
     opts:
-      title: Disable indexing during the build
-      summary: Could make the build faster by disabling the indexing during the build run.
+      category: xcodebuild configuration
+      title: Build settings
+      summary: Build settings to override the project's build settings.
       description: |-
-        Could make the build faster by adding `COMPILER_INDEX_STORE_ENABLE=NO` flag to the `xcodebuild` command which will disable the indexing during the build.
+        Build settings to override the project's build settings.
 
-        Indexing is needed for
-        
-        * Autocomplete
-        * Ability to quickly jump to definition
-        * Get class and method help by alt clicking.
+        The input value sets xcodebuild's `-xcconfig` option.
 
-        Which are not needed in CI environment.
-
-        **Note:** In Xcode you can turn off the `Index-WhileBuilding` feature  by disabling the `Enable Index-WhileBuilding Functionality` in the `Build Settings`.<br/>
-        In CI environment you can disable it by adding `COMPILER_INDEX_STORE_ENABLE=NO` flag to the `xcodebuild` command.
-      value_options:
-        - "yes"
-        - "no"
-  - cache_level: swift_packages
-    opts:
-      title: Enable caching of Swift Package Manager packages
-      description: |-
-        Available options:
-        - `none` : Disable caching
-        - `swift_packages` : Cache Swift PM packages added to the Xcode project
-      value_options:
-      - "none"
-      - "swift_packages"
-      is_required: true
   - xcodebuild_options: ""
     opts:
-      category: Debug
-      title: Additional options for xcodebuild call
+      category: xcodebuild configuration
+      title: Additional options for the `xcodebuild` command
+      summary: Additional options to be added to the executed `xcodebuild` command.
       description: |-
-        Options added to the end of the xcodebuild call.
-        You can use multiple options, separated by a space
-        character. Example: `-xcconfig PATH -verbose`
+        Additional options to be added to the executed `xcodebuild` command.
+
+  # xcodebuild log formatting
+
+  - log_formatter: xcpretty
+    opts:
+      category: xcodebuild log formatting
+      title: Log formatter
+      summary: Defines how `xcodebuild` command's log is formatted.
+      description: |-
+        Defines how `xcodebuild` command's log is formatted.
+
+        Available options:
+        - `xcpretty`: The xcodebuild command’s output will be prettified by xcpretty.
+        - `xcodebuild`: Only the last 20 lines of raw xcodebuild output will be visible in the build log.
+
+        The raw xcodebuild log will be exported in both cases.
+      value_options:
+        - xcpretty
+        - xcodebuild
+      is_required: true
+
+  # Step output configuration
+
   - output_dir: $BITRISE_DEPLOY_DIR
     opts:
-      category: Debug
+      category: Step output configuration
       title: Output directory path
-      summary: ""
+      summary: This directory will contain the generated artifacts.
       description: |-
-        This directory will contain the generated .app artifacts.
+        This directory will contain the generated artifacts.
       is_required: true
-  - output_tool: xcpretty
+
+  # Caching
+
+  - cache_level: "swift_packages"
     opts:
-      category: Debug
-      title: Output tool
+      category: Caching
+      title: Enable collecting cache content
+      summary: Defines what cache content should be automatically collected.
       description: |-
-        If output_tool is set to xcpretty, the xcodebuild output will be prettified by xcpretty.
-        If output_tool is set to xcodebuild, the raw xcodebuild output will be printed.
+        Defines what cache content should be automatically collected.
+
+        Available options:
+        - `none`: Disable collecting cache content.
+        - `swift_packages`: Collect Swift PM packages added to the Xcode project.
       value_options:
-      - xcpretty
-      - xcodebuild
+        - "none"
+        - "swift_packages"
       is_required: true
-      is_expand: false
+
+  # Debugging
+
   - verbose_log: "no"
     opts:
-      category: Debug
-      title: Enable verbose logging?
-      description: Enable verbose logging?
-      is_required: true
+      category: Debugging
+      title: Enable verbose logging
+      summary: If this input is set, the Step will print additional logs for debugging.
+      description: |-
+        If this input is set, the Step will print additional logs for debugging.
       value_options:
       - "yes"
       - "no"
+      is_required: true
 
 outputs:
   - BITRISE_TEST_DIR_PATH:

--- a/step.yml
+++ b/step.yml
@@ -103,10 +103,19 @@ inputs:
   - xcconfig_content: "COMPILER_INDEX_STORE_ENABLE = NO"
     opts:
       category: xcodebuild configuration
-      title: Build settings
+      title: Build settings (xcconfig)
       summary: Build settings to override the project's build settings.
       description: |-
         Build settings to override the project's build settings.
+
+        Build settings must be separated by newline character (`\n`).
+
+        Example:
+
+        ```
+        COMPILER_INDEX_STORE_ENABLE = NO
+        ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*] = YES
+        ```
 
         The input value sets xcodebuild's `-xcconfig` option.
 

--- a/step.yml
+++ b/step.yml
@@ -200,8 +200,9 @@ outputs:
 - BITRISE_TEST_BUNDLE_ZIP_PATH:
   opts:
     title: "The built test directory and the built xctestrun file compressed as a single zip"
-- BITRISE_XCODEBUILD_LOG_PATH:
+- BITRISE_XCODE_RAW_RESULT_TEXT_PATH:
   opts:
-    title: xcodebuild command log file path
+    title: The full, raw build output file path
     description: |-
-      The step exports the `xcodebuild build-for-testing` command output log.
+      This is the path of the raw build results log file.
+      If `output_tool=xcpretty` and the build fails this log will contain the build output.

--- a/step.yml
+++ b/step.yml
@@ -77,7 +77,7 @@ inputs:
         The input value sets xcodebuild's `-scheme` option.
       is_required: true
 
-  - configuration:
+  - configuration: Debug
     opts:
       title: Build Configuration
       summary: Xcode Build Configuration.
@@ -87,6 +87,7 @@ inputs:
         If not specified, the default Build Configuration will be used.
 
         The input value sets xcodebuild's `-configuration` option.
+      is_required: true
 
   - destination: generic/platform=iOS
     opts:

--- a/step.yml
+++ b/step.yml
@@ -205,4 +205,3 @@ outputs:
     title: The full, raw build output file path
     description: |-
       This is the path of the raw build results log file.
-      If `output_tool=xcpretty` and the build fails this log will contain the build output.

--- a/step.yml
+++ b/step.yml
@@ -1,4 +1,4 @@
-title: "[BETA] Xcode Build for testing for iOS"
+title: "Xcode Build for testing for iOS"
 summary: Performs xcodebuild's build-for-testing action
 description: |- 
   The Step runs Xcode's `xcodebuild` command with the `build-for-testing` option. This builds your app for testing and also creates an `.xctestrun` file. 

--- a/step.yml
+++ b/step.yml
@@ -1,52 +1,51 @@
 title: "Xcode Build for testing for iOS"
 summary: Performs xcodebuild's build-for-testing action
-description: |- 
+description: |-
   The Step runs Xcode's `xcodebuild` command with the `build-for-testing` option. This builds your app for testing and also creates an `.xctestrun` file. 
-  
+
   ### Configuring the Step 
-  
+
   At a minimum, the Step needs valid values for three inputs:
-  
+
   - **Project (or Workspace) path**: This is the path to the `.xcodeproj` or `.xcworkspace` file. In most cases, leave it on the default value.
   - **Scheme name**: The name of your Xcode scheme. By default, the Step will use the scheme that was set when you added the app on Bitrise.
   - **Device destination**: The device and platform type to build the tests for. For available values call, `man xcodebuild` and check the Destinations section. 
   We also recommend checking out our [System reports page](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports) on GitHub: you can check out the available, pre-installed simulators and other tools. 
-  
+
   Optionally, you can define the configuration to use in the **Configuration name** input. Normally, the scheme defines the configuration type, such as **debug** or **release**.
-  
+
   The Step can also cache your Swift PM dependencies. To enable caching, make sure the **Enable caching of Swift Package Manager packages** input is set to `swift_packages`.
-  
+
   ### Troubleshooting
-  
+
   In the **Debug** option group, you can:
-  
-  - Add additional flags to the `xcodebuild` command. 
+
+  - Add additional flags to the xcodebuild command.
   - Enable verbose logging.
   - Change the output directory path and the output tool.
-  
+
   ### Useful links
-  
+
   - [Running Xcode tests](https://devcenter.bitrise.io/testing/running-xcode-tests/)
   - [Building from the Command Line with Xcode](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
-  
+
   ### Related Steps 
-  
+
   - [Xcode Test for iOS](https://www.bitrise.io/integrations/steps/xcode-test)
   - [Xcode Analyze](https://www.bitrise.io/integrations/steps/xcode-analyze)
- 
 
 website: https://github.com/bitrise-steplib/steps-xcode-build-for-test
 source_code_url: https://github.com/bitrise-steplib/steps-xcode-build-for-test
 support_url: https://github.com/bitrise-steplib/steps-xcode-build-for-test/issues
 
 project_type_tags:
-  - ios
-  - react-native
-  - cordova
-  - ionic
+- ios
+- react-native
+- cordova
+- ionic
 
 type_tags:
-  - build
+- build
 
 deps:
   check_only:
@@ -57,152 +56,152 @@ toolkit:
     package_name: github.com/bitrise-steplib/steps-xcode-build-for-test
 
 inputs:
-  - project_path: $BITRISE_PROJECT_PATH
-    opts:
-      title: Project path
-      summary: Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
-      description: |-
-        Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
+- project_path: $BITRISE_PROJECT_PATH
+  opts:
+    title: Project path
+    summary: Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
+    description: |-
+      Xcode Project (`.xcodeproj`) or Workspace (`.xcworkspace`) path.
 
-        The input value sets xcodebuild's `-project` or `-workspace` option.
-      is_required: true
+      The input value sets xcodebuild's `-project` or `-workspace` option.
+    is_required: true
 
-  - scheme: $BITRISE_SCHEME
-    opts:
-      title: Scheme
-      summary: Xcode Scheme name.
-      description: |-
-        Xcode Scheme name.
+- scheme: $BITRISE_SCHEME
+  opts:
+    title: Scheme
+    summary: Xcode Scheme name.
+    description: |-
+      Xcode Scheme name.
 
-        The input value sets xcodebuild's `-scheme` option.
-      is_required: true
+      The input value sets xcodebuild's `-scheme` option.
+    is_required: true
 
-  - configuration: Debug
-    opts:
-      title: Build Configuration
-      summary: Xcode Build Configuration.
-      description: |-
-        Xcode Build Configuration.
+- configuration: Debug
+  opts:
+    title: Build Configuration
+    summary: Xcode Build Configuration.
+    description: |-
+      Xcode Build Configuration.
 
-        If not specified, the default Build Configuration will be used.
+      If not specified, the default Build Configuration will be used.
 
-        The input value sets xcodebuild's `-configuration` option.
-      is_required: true
+      The input value sets xcodebuild's `-configuration` option.
+    is_required: true
 
-  - destination: generic/platform=iOS
-    opts:
-      title: Device destination specifier
-      summary: Destination specifier describes the device to use as a destination.
-      description: |-
-        Destination specifier describes the device to use as a destination.
+- destination: generic/platform=iOS
+  opts:
+    title: Device destination specifier
+    summary: Destination specifier describes the device to use as a destination.
+    description: |-
+      Destination specifier describes the device to use as a destination.
 
-        The input value sets xcodebuild's `-destination` option.
-      is_required: true
+      The input value sets xcodebuild's `-destination` option.
+    is_required: true
 
-  # xcodebuild configuration
+# xcodebuild configuration
 
-  - xcconfig_content: "COMPILER_INDEX_STORE_ENABLE = NO"
-    opts:
-      category: xcodebuild configuration
-      title: Build settings (xcconfig)
-      summary: Build settings to override the project's build settings.
-      description: |-
-        Build settings to override the project's build settings.
+- xcconfig_content: "COMPILER_INDEX_STORE_ENABLE = NO"
+  opts:
+    category: xcodebuild configuration
+    title: Build settings (xcconfig)
+    summary: Build settings to override the project's build settings.
+    description: |-
+      Build settings to override the project's build settings.
 
-        Build settings must be separated by newline character (`\n`).
+      Build settings must be separated by newline character (`\n`).
 
-        Example:
+      Example:
 
-        ```
-        COMPILER_INDEX_STORE_ENABLE = NO
-        ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*] = YES
-        ```
+      ```
+      COMPILER_INDEX_STORE_ENABLE = NO
+      ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*] = YES
+      ```
 
-        The input value sets xcodebuild's `-xcconfig` option.
+      The input value sets xcodebuild's `-xcconfig` option.
 
-  - xcodebuild_options: ""
-    opts:
-      category: xcodebuild configuration
-      title: Additional options for the `xcodebuild` command
-      summary: Additional options to be added to the executed `xcodebuild` command.
-      description: |-
-        Additional options to be added to the executed `xcodebuild` command.
+- xcodebuild_options: ""
+  opts:
+    category: xcodebuild configuration
+    title: Additional options for the xcodebuild command
+    summary: Additional options to be added to the executed xcodebuild command.
+    description: |-
+      Additional options to be added to the executed xcodebuild command.
 
-  # xcodebuild log formatting
+# xcodebuild log formatting
 
-  - log_formatter: xcpretty
-    opts:
-      category: xcodebuild log formatting
-      title: Log formatter
-      summary: Defines how `xcodebuild` command's log is formatted.
-      description: |-
-        Defines how `xcodebuild` command's log is formatted.
+- log_formatter: xcpretty
+  opts:
+    category: xcodebuild log formatting
+    title: Log formatter
+    summary: Defines how xcodebuild command's log is formatted.
+    description: |-
+      Defines how xcodebuild command's log is formatted.
 
-        Available options:
-        - `xcpretty`: The xcodebuild command’s output will be prettified by xcpretty.
-        - `xcodebuild`: Only the last 20 lines of raw xcodebuild output will be visible in the build log.
+      Available options:
+      - `xcpretty`: The xcodebuild command’s output will be prettified by xcpretty.
+      - `xcodebuild`: Only the last 20 lines of raw xcodebuild output will be visible in the build log.
 
-        The raw xcodebuild log will be exported in both cases.
-      value_options:
-        - xcpretty
-        - xcodebuild
-      is_required: true
+      The raw xcodebuild log will be exported in both cases.
+    value_options:
+    - xcpretty
+    - xcodebuild
+    is_required: true
 
-  # Step output configuration
+# Step output configuration
 
-  - output_dir: $BITRISE_DEPLOY_DIR
-    opts:
-      category: Step output configuration
-      title: Output directory path
-      summary: This directory will contain the generated artifacts.
-      description: |-
-        This directory will contain the generated artifacts.
-      is_required: true
+- output_dir: $BITRISE_DEPLOY_DIR
+  opts:
+    category: Step output configuration
+    title: Output directory path
+    summary: This directory will contain the generated artifacts.
+    description: |-
+      This directory will contain the generated artifacts.
+    is_required: true
 
-  # Caching
+# Caching
 
-  - cache_level: "swift_packages"
-    opts:
-      category: Caching
-      title: Enable collecting cache content
-      summary: Defines what cache content should be automatically collected.
-      description: |-
-        Defines what cache content should be automatically collected.
+- cache_level: "swift_packages"
+  opts:
+    category: Caching
+    title: Enable collecting cache content
+    summary: Defines what cache content should be automatically collected.
+    description: |-
+      Defines what cache content should be automatically collected.
 
-        Available options:
-        - `none`: Disable collecting cache content.
-        - `swift_packages`: Collect Swift PM packages added to the Xcode project.
-      value_options:
-        - "none"
-        - "swift_packages"
-      is_required: true
+      Available options:
+      - `none`: Disable collecting cache content.
+      - `swift_packages`: Collect Swift PM packages added to the Xcode project.
+    value_options:
+    - "none"
+    - "swift_packages"
+    is_required: true
 
-  # Debugging
+# Debugging
 
-  - verbose_log: "no"
-    opts:
-      category: Debugging
-      title: Enable verbose logging
-      summary: If this input is set, the Step will print additional logs for debugging.
-      description: |-
-        If this input is set, the Step will print additional logs for debugging.
-      value_options:
-      - "yes"
-      - "no"
-      is_required: true
+- verbose_log: "no"
+  opts:
+    category: Debugging
+    title: Enable verbose logging
+    summary: If this input is set, the Step will print additional logs for debugging.
+    description: |-
+      If this input is set, the Step will print additional logs for debugging.
+    value_options:
+    - "yes"
+    - "no"
+    is_required: true
 
 outputs:
-  - BITRISE_TEST_DIR_PATH:
-    opts:
-      title: "Path to the built test directory (example: PROJECT_DERIVED_DATA/Build/Products/Debug-iphoneos)"
-  - BITRISE_XCTESTRUN_FILE_PATH:
-    opts:
-      title: "Path to the built xctestrun file (example: PROJECT_DERIVED_DATA/Build/Products/ios-simple-objc_iphoneos12.0-arm64e.xctestrun)"
-  - BITRISE_TEST_BUNDLE_ZIP_PATH:
-    opts:
-      title: "The built test directory and the built xctestrun file compressed as a single zip"
-  - BITRISE_XCODEBUILD_LOG_PATH:
-    opts:
-      title: xcodebuild command log file path
-      description: |-
-        The step exports the `xcodebuild build-for-testing` command output log.
+- BITRISE_TEST_DIR_PATH:
+  opts:
+    title: "Path to the built test directory (example: PROJECT_DERIVED_DATA/Build/Products/Debug-iphoneos)"
+- BITRISE_XCTESTRUN_FILE_PATH:
+  opts:
+    title: "Path to the built xctestrun file (example: PROJECT_DERIVED_DATA/Build/Products/ios-simple-objc_iphoneos12.0-arm64e.xctestrun)"
+- BITRISE_TEST_BUNDLE_ZIP_PATH:
+  opts:
+    title: "The built test directory and the built xctestrun file compressed as a single zip"
+- BITRISE_XCODEBUILD_LOG_PATH:
+  opts:
+    title: xcodebuild command log file path
+    description: |-
+      The step exports the `xcodebuild build-for-testing` command output log.

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/build.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/build.go
@@ -47,6 +47,7 @@ type CommandBuilder struct {
 	scheme        string
 	configuration string
 	destination   string
+	xcconfigPath  string
 
 	// buildsetting
 	forceDevelopmentTeam              string
@@ -85,15 +86,21 @@ func (c *CommandBuilder) SetScheme(scheme string) *CommandBuilder {
 	return c
 }
 
+// SetConfiguration ...
+func (c *CommandBuilder) SetConfiguration(configuration string) *CommandBuilder {
+	c.configuration = configuration
+	return c
+}
+
 // SetDestination ...
 func (c *CommandBuilder) SetDestination(destination string) *CommandBuilder {
 	c.destination = destination
 	return c
 }
 
-// SetConfiguration ...
-func (c *CommandBuilder) SetConfiguration(configuration string) *CommandBuilder {
-	c.configuration = configuration
+// SetXCConfigPath ...
+func (c *CommandBuilder) SetXCConfigPath(xcconfigPath string) *CommandBuilder {
+	c.xcconfigPath = xcconfigPath
 	return c
 }
 
@@ -182,6 +189,15 @@ func (c *CommandBuilder) args() []string {
 		slice = append(slice, "-configuration", c.configuration)
 	}
 
+	if c.destination != "" {
+		// "-destination" "id=07933176-D03B-48D3-A853-0800707579E6" => (need the plus `"` marks between the `destination` and the `id`)
+		slice = append(slice, "-destination", c.destination)
+	}
+
+	if c.xcconfigPath != "" {
+		slice = append(slice, "-xcconfig", c.xcconfigPath)
+	}
+
 	if c.disableCodesign {
 		slice = append(slice, "CODE_SIGNING_ALLOWED=NO")
 	} else {
@@ -200,12 +216,6 @@ func (c *CommandBuilder) args() []string {
 		if c.forceCodeSignIdentity != "" {
 			slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
 		}
-	}
-
-	if c.destination != "" {
-		// "-destination" "id=07933176-D03B-48D3-A853-0800707579E6" => (need the plus `"` marks between the `destination` and the `id`)
-		slice = append(slice, "-destination")
-		slice = append(slice, c.destination)
 	}
 
 	if c.disableIndexWhileBuilding {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/bitrise-io/go-utils/pretty
 github.com/bitrise-io/go-utils/sliceutil
 github.com/bitrise-io/go-utils/stringutil
 github.com/bitrise-io/go-utils/ziputil
-# github.com/bitrise-io/go-xcode v0.0.0-20210927150020-dd11ae1c9008
+# github.com/bitrise-io/go-xcode v0.0.0-20210928140350-ec12eb8661c0
 ## explicit; go 1.15
 github.com/bitrise-io/go-xcode/models
 github.com/bitrise-io/go-xcode/utility


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MAJOR* [version update](https://semver.org/)

### Context

**We are revamping several Xcode-related steps to a new, streamlined input-output structure to prepare for future changes.**
* Most of the inputs have updated name (key), title, description. Some inputs were removed because they no longer serve a purpose.
* Read the changelog for full details.

### Changes

* New input: Build settings (`xcconfig_content`). Allows you to override the project's build settings. Creates a temporary file with the given input value as content and passes it to `xcodebuild`'s `-xcconfig` parameter.
* Removed `disable_index_while_building ` in favor of `xcconfig_content`.
* Renamed `output_tool` to `log_formatter`.
* Re-organized categories.
* Updated titles, summaries, and descriptions across the board.
* xcodebuild log output env key updated to BITRISE_XCODE_RAW_RESULT_TEXT_PATH (this is what was exposed by the step).

### Out of Scope

* Revamping outputs.

### Decisions

**`configuration` input's default value is kept on `Debug`:**

The step uses the configuration provided by `xcodebuild "-showBuildSettings"`, to search for the built test bundles.

`xcodebuild build-for-testing` uses the `Debug` configuration by default, while `xcodebuild "-showBuildSettings"` prints the configuration for command-line builds, which is `Release` by default. That's why if `configuration` is not provided the Step fails to find the built test bundles.

To solve this issue `configuration` input became required and the input default value is set to `Debug`.
