### PR TITLE
Partial ideal step refactor and updated error messages

### DIFF
--- a/build.go
+++ b/build.go
@@ -26,10 +26,10 @@ func runCommandWithRetry(cmd *xcodebuild.CommandBuilder, useXcpretty bool, swift
 	output, buildInterval, err := runCommand(cmd, useXcpretty)
 	buildInterval.end = time.Now()
 	if err != nil && swiftPackagesPath != "" && strings.Contains(output, cache.SwiftPackagesStateInvalid) {
-		log.Warnf("Build failed, swift packages cache is in an invalid state, error: %s", err)
+		log.Warnf("Build failed, swift packages cache is in an invalid state: %s", err)
 		log.RWarnf("xcode-build-for-test", "swift-packages-cache-invalid", nil, "swift packages cache is in an invalid state")
 		if err := os.RemoveAll(swiftPackagesPath); err != nil {
-			return output, buildInterval, fmt.Errorf("failed to remove invalid Swift package caches, error: %s", err)
+			return output, buildInterval, fmt.Errorf("failed to remove invalid swift package caches: %w", err)
 		}
 		return runCommand(cmd, useXcpretty)
 	}

--- a/codesign.go
+++ b/codesign.go
@@ -18,21 +18,20 @@ import (
 )
 
 type CodesignManagerOpts struct {
+	ProjectPath               string
+	Scheme                    string
+	Configuration             string
 	CodeSigningAuthSource     string
+	RegisterTestDevices       bool
+	MinDaysProfileValid       int
+	TeamID                    string
 	CertificateURLList        string
 	CertificatePassphraseList stepconf.Secret
 	KeychainPath              string
 	KeychainPassword          stepconf.Secret
 	BuildURL                  string
 	BuildAPIToken             stepconf.Secret
-	TeamID                    string
-	RegisterTestDevices       bool
-	MinDaysProfileValid       int
 	VerboseLog                bool
-
-	ProjectPath   string
-	Scheme        string
-	Configuration string
 }
 
 func createCodesignManager(managerOpts CodesignManagerOpts, xcodeMajorVersion int64, logger log.Logger, cmdFactory command.Factory) (codesign.Manager, error) {

--- a/codesign.go
+++ b/codesign.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/bitrise-io/go-steputils/v2/stepconf"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -16,9 +17,27 @@ import (
 	"github.com/bitrise-io/go-xcode/v2/codesign"
 )
 
-func createCodesignManager(config Config, xcodeMajorVersion int64, logger log.Logger, cmdFactory command.Factory) (codesign.Manager, error) {
+type CodesignManagerOpts struct {
+	CodeSigningAuthSource     string
+	CertificateURLList        string
+	CertificatePassphraseList stepconf.Secret
+	KeychainPath              string
+	KeychainPassword          stepconf.Secret
+	BuildURL                  string
+	BuildAPIToken             stepconf.Secret
+	TeamID                    string
+	RegisterTestDevices       bool
+	MinDaysProfileValid       int
+	VerboseLog                bool
+
+	ProjectPath   string
+	Scheme        string
+	Configuration string
+}
+
+func createCodesignManager(managerOpts CodesignManagerOpts, xcodeMajorVersion int64, logger log.Logger, cmdFactory command.Factory) (codesign.Manager, error) {
 	var authType codesign.AuthType
-	switch config.CodeSigningAuthSource {
+	switch managerOpts.CodeSigningAuthSource {
 	case codeSignSourceAppleID:
 		authType = codesign.AppleIDAuth
 	case codeSignSourceAPIKey:
@@ -30,10 +49,10 @@ func createCodesignManager(config Config, xcodeMajorVersion int64, logger log.Lo
 	codesignInputs := codesign.Input{
 		AuthType:                  authType,
 		DistributionMethod:        string(autocodesign.Development),
-		CertificateURLList:        config.CertificateURLList,
-		CertificatePassphraseList: config.CertificatePassphraseList,
-		KeychainPath:              config.KeychainPath,
-		KeychainPassword:          config.KeychainPassword,
+		CertificateURLList:        managerOpts.CertificateURLList,
+		CertificatePassphraseList: managerOpts.CertificatePassphraseList,
+		KeychainPath:              managerOpts.KeychainPath,
+		KeychainPassword:          managerOpts.KeychainPassword,
 	}
 
 	codesignConfig, err := codesign.ParseConfig(codesignInputs, cmdFactory)
@@ -44,7 +63,7 @@ func createCodesignManager(config Config, xcodeMajorVersion int64, logger log.Lo
 	var serviceConnection *devportalservice.AppleDeveloperConnection = nil
 	devPortalClientFactory := devportalclient.NewFactory(logger)
 	if authType == codesign.APIKeyAuth || authType == codesign.AppleIDAuth {
-		if serviceConnection, err = devPortalClientFactory.CreateBitriseConnection(config.BuildURL, string(config.BuildAPIToken)); err != nil {
+		if serviceConnection, err = devPortalClientFactory.CreateBitriseConnection(managerOpts.BuildURL, string(managerOpts.BuildAPIToken)); err != nil {
 			return codesign.Manager{}, err
 		}
 	}
@@ -57,19 +76,19 @@ func createCodesignManager(config Config, xcodeMajorVersion int64, logger log.Lo
 	opts := codesign.Opts{
 		AuthType:                   authType,
 		ShouldConsiderXcodeSigning: true,
-		TeamID:                     config.TeamID,
+		TeamID:                     managerOpts.TeamID,
 		ExportMethod:               codesignConfig.DistributionMethod,
 		XcodeMajorVersion:          int(xcodeMajorVersion),
-		RegisterTestDevices:        config.RegisterTestDevices,
+		RegisterTestDevices:        managerOpts.RegisterTestDevices,
 		SignUITests:                true,
-		MinDaysProfileValidity:     config.MinDaysProfileValid,
-		IsVerboseLog:               config.VerboseLog,
+		MinDaysProfileValidity:     managerOpts.MinDaysProfileValid,
+		IsVerboseLog:               managerOpts.VerboseLog,
 	}
 
 	project, err := projectmanager.NewProject(projectmanager.InitParams{
-		ProjectOrWorkspacePath: config.ProjectPath,
-		SchemeName:             config.Scheme,
-		ConfigurationName:      config.Configuration,
+		ProjectOrWorkspacePath: managerOpts.ProjectPath,
+		SchemeName:             managerOpts.Scheme,
+		ConfigurationName:      managerOpts.Configuration,
 	})
 	if err != nil {
 		return codesign.Manager{}, fmt.Errorf("failed to open project: %s", err)

--- a/codesign.go
+++ b/codesign.go
@@ -56,10 +56,10 @@ func createCodesignManager(managerOpts CodesignManagerOpts, xcodeMajorVersion in
 
 	codesignConfig, err := codesign.ParseConfig(codesignInputs, cmdFactory)
 	if err != nil {
-		return codesign.Manager{}, fmt.Errorf("issue with input: %s", err)
+		return codesign.Manager{}, fmt.Errorf("issue with input: %w", err)
 	}
 
-	var serviceConnection *devportalservice.AppleDeveloperConnection = nil
+	var serviceConnection *devportalservice.AppleDeveloperConnection
 	devPortalClientFactory := devportalclient.NewFactory(logger)
 	if authType == codesign.APIKeyAuth || authType == codesign.AppleIDAuth {
 		if serviceConnection, err = devPortalClientFactory.CreateBitriseConnection(managerOpts.BuildURL, string(managerOpts.BuildAPIToken)); err != nil {
@@ -90,7 +90,7 @@ func createCodesignManager(managerOpts CodesignManagerOpts, xcodeMajorVersion in
 		ConfigurationName:      managerOpts.Configuration,
 	})
 	if err != nil {
-		return codesign.Manager{}, fmt.Errorf("failed to open project: %s", err)
+		return codesign.Manager{}, fmt.Errorf("failed to open project: %w", err)
 	}
 
 	return codesign.NewManagerWithProject(

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -110,10 +110,10 @@ workflows:
     after_run:
     - _run
 
-  test_build_output_spaces_custom_build_options:
+  test_build_output_spaces_custom_build_options_automatic_signing:
     envs:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-simple-objc-with-uitest.git
-    - SAMPLE_APP_BRANCH: renamed-scheme
+    - SAMPLE_APP_BRANCH: automatic-signing
     - BITRISE_PROJECT_PATH: ./ios-simple-objc/ios-simple-objc.xcodeproj
     - BITRISE_SCHEME: Scheme with spaces
     - XCODE_BUILD_OPTIONS: -derivedDataPath $BITRISE_SOURCE_DIR/_tmp/ddata -destination generic/platform=iOS

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,6 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+h
 github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.2 h1:Uv/cBOJ/qZpitjOpyS8orafee3wk66OwvRTbqA2fr+4=
 github.com/bitrise-io/go-xcode v1.0.2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.7 h1:t91jjaL2tfSw90XSTuH8xavu2By+SIb79HERKUcKSMc=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.7/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.7.0.20220127124329-71a6c3e80c5f h1:r+K5yhDm5K8nBCW97waPSAaSbgJxQp6BIOmJJZ455hA=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.7.0.20220127124329-71a6c3e80c5f/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.8 h1:Gv3PVzZNjshcGm0Z9vpK1d01/mDqUrapRkUlMSKUfnw=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.8/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func run() int {
 	}
 
 	if err := s.InstallDependencies(cfg.XCPretty); err != nil {
-		log.Warnf("Failed to install deps: %s", err)
+		log.Warnf("Install dependencies: %s", err)
 		log.Printf("Switching to xcodebuild for output tool")
 		cfg.XCPretty = false
 	}
@@ -51,10 +51,10 @@ func run() int {
 	exportErr := s.ExportOutput(exportOpts)
 
 	if runErr != nil {
-		log.Errorf(runErr.Error())
+		log.Errorf("Run: %s", runErr)
 	}
 	if exportErr != nil {
-		log.Errorf(exportErr.Error())
+		log.Errorf("Export outputs: %s", exportErr)
 	}
 	if runErr != nil || exportErr != nil {
 		return 1

--- a/main.go
+++ b/main.go
@@ -24,29 +24,14 @@ func run() int {
 		cfg.XCPretty = false
 	}
 
-	runOpts := RunOpts{
-		XCPretty:          cfg.XCPretty,
-		CodesignManager:   cfg.CodesignManager,
-		SwiftPackagesPath: cfg.SwiftPackagesPath,
-		OutputDir:         cfg.OutputDir,
-		ProjectPath:       cfg.ProjectPath,
-		Scheme:            cfg.Scheme,
-		Configuration:     cfg.Configuration,
-		Destination:       cfg.Destination,
-		XCConfigContent:   cfg.XCConfigContent,
-		XcodebuildOptions: cfg.XcodebuildOptions,
-	}
-	runOut, runErr := s.Run(runOpts)
+	runOut, runErr := s.Run(cfg)
 
 	exportOpts := ExportOpts{
 		OutputDir:         cfg.OutputDir,
-		ProjectPath:       cfg.ProjectPath,
-		Scheme:            cfg.Scheme,
-		Configuration:     cfg.Configuration,
-		XcodebuildOptions: cfg.XcodebuildOptions,
-		CacheLevel:        cfg.CacheLevel,
-		BuildInterval:     runOut.BuildInterval,
 		XcodebuildTestLog: runOut.XcodebuildLog,
+		BuiltTestDir:      runOut.BuiltTestDir,
+		XctestrunPth:      runOut.XctestrunPth,
+		SYMRoot:           runOut.SYMRoot,
 	}
 	exportErr := s.ExportOutput(exportOpts)
 

--- a/main.go
+++ b/main.go
@@ -1,372 +1,68 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/bitrise-io/go-steputils/output"
-	"github.com/bitrise-io/go-steputils/tools"
-	"github.com/bitrise-io/go-steputils/v2/stepconf"
-	"github.com/bitrise-io/go-utils/errorutil"
 	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/stringutil"
-	"github.com/bitrise-io/go-utils/v2/command"
-	"github.com/bitrise-io/go-utils/v2/env"
-	v2fileutil "github.com/bitrise-io/go-utils/v2/fileutil"
-	v2log "github.com/bitrise-io/go-utils/v2/log"
-	v2pathutil "github.com/bitrise-io/go-utils/v2/pathutil"
-	"github.com/bitrise-io/go-xcode/utility"
-	"github.com/bitrise-io/go-xcode/v2/codesign"
-	"github.com/bitrise-io/go-xcode/v2/xcconfig"
-	"github.com/bitrise-io/go-xcode/xcodebuild"
-	cache "github.com/bitrise-io/go-xcode/xcodecache"
-	"github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace"
-	"github.com/bitrise-io/go-xcode/xcpretty"
-	"github.com/kballard/go-shellquote"
 )
-
-const (
-	xcodebuildLogPath = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
-
-	// Code Signing Authentication Source
-	codeSignSourceOff     = "off"
-	codeSignSourceAPIKey  = "api-key"
-	codeSignSourceAppleID = "apple-id"
-)
-
-// Config ...
-type Config struct {
-	ProjectPath   string `env:"project_path,required"`
-	Scheme        string `env:"scheme,required"`
-	Configuration string `env:"configuration"`
-	Destination   string `env:"destination,required"`
-
-	XCConfigContent   string `env:"xcconfig_content"`
-	XcodebuildOptions string `env:"xcodebuild_options"`
-
-	LogFormatter string `env:"log_formatter,opt[xcpretty,xcodebuild]"`
-
-	OutputDir string `env:"output_dir,required"`
-
-	CacheLevel string `env:"cache_level,opt[none,swift_packages]"`
-
-	VerboseLog bool `env:"verbose_log,opt[yes,no]"`
-
-	CodeSigningAuthSource     string          `env:"automatic_code_signing,opt[off,api-key,apple-id]"`
-	CertificateURLList        string          `env:"certificate_url_list"`
-	CertificatePassphraseList stepconf.Secret `env:"passphrase_list"`
-	KeychainPath              string          `env:"keychain_path"`
-	KeychainPassword          stepconf.Secret `env:"keychain_password"`
-	RegisterTestDevices       bool            `env:"register_test_devices,opt[yes,no]"`
-	MinDaysProfileValid       int             `env:"min_profile_validity,required"`
-	TeamID                    string          `env:"apple_team_id"`
-	BuildURL                  string          `env:"BITRISE_BUILD_URL"`
-	BuildAPIToken             stepconf.Secret `env:"BITRISE_BUILD_API_TOKEN"`
-}
 
 func main() {
-	//
-	// Config
-	var cfg Config
-	parser := stepconf.NewInputParser(env.NewRepository())
-	if err := parser.Parse(&cfg); err != nil {
-		failf("Issue with input: %s", err)
-	}
-	logger := v2log.NewLogger()
-	logger.EnableDebugLog(cfg.VerboseLog)
-	log.SetEnableDebugLog(cfg.VerboseLog)
-
-	stepconf.Print(cfg)
-	fmt.Println()
-
-	absProjectPath, err := filepath.Abs(cfg.ProjectPath)
-	if err != nil {
-		failf("Failed to expand ProjectPath (%s), error: %s", cfg.ProjectPath, err)
-	}
-
-	// abs out dir pth
-	absOutputDir, err := pathutil.AbsPath(cfg.OutputDir)
-	if err != nil {
-		failf("Failed to expand OutputDir (%s), error: %s", cfg.OutputDir, err)
-	}
-
-	if exist, err := pathutil.IsPathExists(absOutputDir); err != nil {
-		failf("Failed to check if OutputDir exist, error: %s", err)
-	} else if !exist {
-		if err := os.MkdirAll(absOutputDir, 0777); err != nil {
-			failf("Failed to create OutputDir (%s), error: %s", absOutputDir, err)
-		}
-	}
-
-	// Output files
-	rawXcodebuildOutputLogPath := filepath.Join(absOutputDir, "raw-xcodebuild-output.log")
-
-	//
-	// Ensure xcpretty
-	// only if output tool is set to xcpretty
-	if cfg.LogFormatter == "xcpretty" {
-		log.Infof("Output tool check:")
-
-		// check if already installed
-		if installed, err := xcpretty.IsInstalled(); err != nil {
-			log.Warnf(" Failed to check if xcpretty is installed, error: %s", err)
-			cfg.LogFormatter = "xcodebuild"
-		} else if !installed {
-			log.Warnf(` xcpretty is not installed`)
-			log.Printf(" Installing...")
-
-			// install if not installed
-			if cmds, err := xcpretty.Install(); err != nil {
-				log.Warnf(" Failed to install xcpretty, error: %s", err)
-				cfg.LogFormatter = "xcodebuild"
-			} else {
-				for _, cmd := range cmds {
-					log.Donef(" $ %s", cmd.PrintableCommandArgs())
-					if err := cmd.Run(); err != nil {
-						log.Warnf(" Failed to install xcpretty, error: %s", err)
-						cfg.LogFormatter = "xcodebuild"
-						break
-					}
-				}
-			}
-		} else {
-			// already installed
-			log.Donef(` xcpretty is installed`)
-		}
-		// warn user if we needed to switch back from xcpretty
-		if cfg.LogFormatter != "xcpretty" {
-			log.Warnf(" Switching output tool to xcodebuild")
-		}
-		fmt.Println()
-	}
-
-	// Detect Xcode major version
-	factory := command.NewFactory(env.NewRepository())
-	xcodebuildVersion, err := utility.GetXcodeVersion()
-	if err != nil {
-		failf("Failed to determin xcode version, error: %s", err)
-	}
-	log.Infof("Xcode version: %s (%s)", xcodebuildVersion.Version, xcodebuildVersion.BuildVersion)
-
-	var swiftPackagesPath string
-	if xcodebuildVersion.MajorVersion >= 11 {
-		var err error
-		if swiftPackagesPath, err = cache.SwiftPackagesPath(absProjectPath); err != nil {
-			failf("Failed to get Swift Packages path, error: %s", err)
-		}
-	}
-
-	var codesignManager *codesign.Manager = nil
-	if cfg.CodeSigningAuthSource != codeSignSourceOff {
-		codesignMgr, err := createCodesignManager(cfg, xcodebuildVersion.MajorVersion, logger, factory)
-		if err != nil {
-			failf("%s", err)
-		}
-		codesignManager = &codesignMgr
-	}
-
-	// manage code signing
-	var authOptions *xcodebuild.AuthenticationParams = nil
-	if codesignManager != nil {
-		log.Infof("Preparing code signing assets (certificates, profiles)")
-
-		xcodebuildAuthParams, err := codesignManager.PrepareCodesigning()
-		if err != nil {
-			failf("Failed to prepare code signing assets: %s", err)
-		}
-
-		if xcodebuildAuthParams != nil {
-			privateKey, err := xcodebuildAuthParams.WritePrivateKeyToFile()
-			if err != nil {
-				failf("%s", err)
-			}
-
-			defer func() {
-				if err := os.Remove(privateKey); err != nil {
-					log.Warnf("failed to remove private key file: %s", err)
-				}
-			}()
-
-			authOptions = &xcodebuild.AuthenticationParams{
-				KeyID:     xcodebuildAuthParams.KeyID,
-				IsssuerID: xcodebuildAuthParams.IssuerID,
-				KeyPath:   privateKey,
-			}
-		}
-	} else {
-		log.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
-	}
-
-	//
-	// Build
-	log.Infof("Build:")
-
-	var customOptions []string
-	// parse custom flags
-	if cfg.XcodebuildOptions != "" {
-		customOptions, err = shellquote.Split(cfg.XcodebuildOptions)
-		if err != nil {
-			failf("Failed to shell split XcodebuildOptions (%s), error: %s", cfg.XcodebuildOptions)
-		}
-	}
-
-	xcconfigWriter := xcconfig.NewWriter(v2pathutil.NewPathProvider(), v2fileutil.NewFileManager())
-	xcconfigPath, err := xcconfigWriter.Write(cfg.XCConfigContent)
-	if err != nil {
-		failf(err.Error())
-	}
-
-	xcodeBuildCmd := xcodebuild.NewCommandBuilder(absProjectPath, xcworkspace.IsWorkspace(absProjectPath), "")
-	xcodeBuildCmd.SetScheme(cfg.Scheme)
-	xcodeBuildCmd.SetConfiguration(cfg.Configuration)
-	xcodeBuildCmd.SetCustomBuildAction("build-for-testing")
-	xcodeBuildCmd.SetDestination(cfg.Destination)
-	xcodeBuildCmd.SetCustomOptions(customOptions)
-	xcodeBuildCmd.SetXCConfigPath(xcconfigPath)
-	if authOptions != nil {
-		xcodeBuildCmd.SetAuthentication(*authOptions)
-	}
-
-	// save the build time frame to find the build generated artifacts
-	rawXcodebuildOut, buildInterval, xcodebuildErr := runCommandWithRetry(xcodeBuildCmd, cfg.LogFormatter == "xcpretty", swiftPackagesPath)
-
-	if err := output.ExportOutputFileContent(rawXcodebuildOut, rawXcodebuildOutputLogPath, xcodebuildLogPath); err != nil {
-		log.Warnf("Failed to export %s, error: %s", xcodebuildLogPath, err)
-	}
-	log.Donef("The xcodebuild command log file path is available in BITRISE_XCODE_RAW_RESULT_TEXT_PATH env: %s", rawXcodebuildOutputLogPath)
-
-	if xcodebuildErr != nil {
-		if cfg.LogFormatter == "xcpretty" {
-			log.Errorf("\nLast lines of the Xcode's build log:")
-			fmt.Println(stringutil.LastNLines(rawXcodebuildOut, 10))
-		}
-		failf("Build failed, error: %s", xcodebuildErr)
-	}
-	fmt.Println()
-
-	//
-	// Export
-	log.Infof("Export:")
-
-	buildSettingsCmd := xcodebuild.NewShowBuildSettingsCommand(absProjectPath)
-	buildSettingsCmd.SetScheme(cfg.Scheme)
-	buildSettingsCmd.SetConfiguration(cfg.Configuration)
-	buildSettingsCmd.SetCustomOptions(append([]string{"build-for-testing"}, customOptions...))
-
-	fmt.Println()
-	log.Donef("$ %s", buildSettingsCmd.PrintableCmd())
-
-	buildSettings, err := buildSettingsCmd.RunAndReturnSettings()
-	if err != nil {
-		failf("failed to read build settings: %s", err)
-	}
-
-	// The path at which all products will be placed when performing a build. Typically this path is not set per target, but is set per-project or per-user.
-	symRoot, err := buildSettings.String("SYMROOT")
-	if err != nil {
-		failf("Failed to parse SYMROOT build setting: %s", err)
-	}
-	log.Printf("SYMROOT: %s", symRoot)
-
-	configuration, err := buildSettings.String("CONFIGURATION")
-	if err != nil {
-		failf("Failed to parse CONFIGURATION build setting: %s", err)
-	}
-	log.Printf("CONFIGURATION: %s", configuration)
-
-	// Without better solution the step collects every xctestrun files and filters them for the build time frame
-	xctestrunPthPattern := filepath.Join(symRoot, fmt.Sprintf("%s*.xctestrun", cfg.Scheme))
-	xctestrunPths, err := filepath.Glob(xctestrunPthPattern)
-	if err != nil {
-		failf("Failed to search for xctestrun file using pattern: %s, error: %s", xctestrunPthPattern, err)
-	}
-	log.Printf("xctestrun paths: %s", strings.Join(xctestrunPths, ", "))
-
-	if len(xctestrunPths) == 0 {
-		failf("No xctestrun file found with pattern: %s", xctestrunPthPattern)
-	}
-
-	var buildXCTestrunPths []string
-	for _, xctestrunPth := range xctestrunPths {
-		info, err := os.Stat(xctestrunPth)
-		if err != nil {
-			failf("Failed to check %s modtime: %s", xctestrunPth, err)
-		}
-
-		if !info.ModTime().Before(buildInterval.start) && !info.ModTime().After(buildInterval.end) {
-			buildXCTestrunPths = append(buildXCTestrunPths, xctestrunPth)
-		}
-	}
-
-	if len(buildXCTestrunPths) == 0 {
-		failf("No xctestrun file generated during the build")
-	} else if len(buildXCTestrunPths) > 1 {
-		failf("Multiple xctestrun file generated during the build:\n%s", strings.Join(buildXCTestrunPths, "\n- "))
-	}
-
-	xctestrunPth := buildXCTestrunPths[0]
-	log.Printf("Built xctestrun path: %s", xctestrunPth)
-
-	// Without better solution the step determines the build target based on the xctestrun file name
-	// ios-simple-objc_iphonesimulator12.0-x86_64.xctestrun
-	var builtForDestination string
-	if strings.Contains(xctestrunPth, fmt.Sprintf("%s_iphonesimulator", cfg.Scheme)) {
-		builtForDestination = "iphonesimulator"
-	} else {
-		builtForDestination = "iphoneos"
-	}
-
-	builtTestDir := filepath.Join(symRoot, fmt.Sprintf("%s-%s", configuration, builtForDestination))
-	if exist, err := pathutil.IsPathExists(builtTestDir); err != nil {
-		failf("Failed to check if built test directory exists at: %s, error: %s", builtTestDir, err)
-	} else if !exist {
-		failf("built test directory does not exist at: %s", builtTestDir)
-	}
-	log.Printf("Built test directory: %s", builtTestDir)
-
-	outputTestBundleZipPath := filepath.Join(absOutputDir, "testbundle.zip")
-	zipCmd := factory.Create("zip", []string{"-r", outputTestBundleZipPath, filepath.Base(builtTestDir), filepath.Base(xctestrunPth)}, &command.Opts{
-		Dir: symRoot,
-	})
-	if out, err := zipCmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
-		if errorutil.IsExitStatusError(err) {
-			failf("%s failed: %s", zipCmd.PrintableCommandArgs(), out)
-		} else {
-			failf("%s failed: %s", zipCmd.PrintableCommandArgs(), err)
-		}
-	}
-	log.Printf("Zipped test bundle: %s", outputTestBundleZipPath)
-
-	outputXCTestrunPth := filepath.Join(absOutputDir, filepath.Base(xctestrunPth))
-	if err := output.ExportOutputFile(xctestrunPth, outputXCTestrunPth, "BITRISE_XCTESTRUN_FILE_PATH"); err != nil {
-		failf("Failed to export BITRISE_XCTESTRUN_FILE_PATH: %s", err)
-	}
-	log.Donef("The built xctestrun file is available in BITRISE_XCTESTRUN_FILE_PATH env: %s", outputXCTestrunPth)
-
-	outputTestDirPath := filepath.Join(absOutputDir, filepath.Base(builtTestDir))
-	if err := output.ExportOutputDir(builtTestDir, outputTestDirPath, "BITRISE_TEST_DIR_PATH"); err != nil {
-		failf("Failed to export BITRISE_TEST_DIR_PATH: %s", err)
-	}
-	log.Donef("The built test directory is available in BITRISE_TEST_DIR_PATH env: %s", outputTestDirPath)
-
-	if err := tools.ExportEnvironmentWithEnvman("BITRISE_TEST_BUNDLE_ZIP_PATH", outputTestBundleZipPath); err != nil {
-		failf("Failed to export BITRISE_TEST_BUNDLE_ZIP_PATH: %s", err)
-	}
-
-	// Cache swift PM
-	if xcodebuildVersion.MajorVersion >= 11 && cfg.CacheLevel == "swift_packages" {
-		if err := cache.CollectSwiftPackages(absProjectPath); err != nil {
-			log.Warnf("Failed to mark swift packages for caching, error: %s", err)
-		}
-	}
-
-	log.Donef("The zipped test bundle is available in BITRISE_TEST_BUNDLE_ZIP_PATH env: %s", outputTestBundleZipPath)
+	os.Exit(run())
 }
 
-func failf(format string, v ...interface{}) {
-	log.Errorf(format, v...)
-	os.Exit(1)
+func run() int {
+	s := createStep()
+	cfg, err := s.ProcessConfig()
+	if err != nil {
+		log.Errorf("Process config: %s", err)
+		return 1
+	}
+
+	if err := s.InstallDependencies(cfg.XCPretty); err != nil {
+		log.Warnf("Failed to install deps: %s", err)
+		log.Printf("Switching to xcodebuild for output tool")
+		cfg.XCPretty = false
+	}
+
+	runOpts := RunOpts{
+		XCPretty:          cfg.XCPretty,
+		CodesignManager:   cfg.CodesignManager,
+		SwiftPackagesPath: cfg.SwiftPackagesPath,
+		OutputDir:         cfg.OutputDir,
+		ProjectPath:       cfg.ProjectPath,
+		Scheme:            cfg.Scheme,
+		Configuration:     cfg.Configuration,
+		Destination:       cfg.Destination,
+		XCConfigContent:   cfg.XCConfigContent,
+		XcodebuildOptions: cfg.XcodebuildOptions,
+	}
+	runOut, runErr := s.Run(runOpts)
+
+	exportOpts := ExportOpts{
+		OutputDir:         cfg.OutputDir,
+		ProjectPath:       cfg.ProjectPath,
+		Scheme:            cfg.Scheme,
+		Configuration:     cfg.Configuration,
+		XcodebuildOptions: cfg.XcodebuildOptions,
+		CacheLevel:        cfg.CacheLevel,
+		BuildInterval:     runOut.BuildInterval,
+		XcodebuildTestLog: runOut.XcodebuildLog,
+	}
+	exportErr := s.ExportOutput(exportOpts)
+
+	if runErr != nil {
+		log.Errorf(runErr.Error())
+	}
+	if exportErr != nil {
+		log.Errorf(exportErr.Error())
+	}
+	if runErr != nil || exportErr != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func createStep() TestBuilder {
+	return NewTestBuilder()
 }

--- a/main.go
+++ b/main.go
@@ -25,15 +25,10 @@ func run() int {
 	}
 
 	runOut, runErr := s.Run(cfg)
-
-	exportOpts := ExportOpts{
-		OutputDir:         cfg.OutputDir,
-		XcodebuildTestLog: runOut.XcodebuildLog,
-		BuiltTestDir:      runOut.BuiltTestDir,
-		XctestrunPth:      runOut.XctestrunPth,
-		SYMRoot:           runOut.SYMRoot,
-	}
-	exportErr := s.ExportOutput(exportOpts)
+	exportErr := s.ExportOutput(ExportOpts{
+		OutputDir: cfg.OutputDir,
+		RunOut:    runOut,
+	})
 
 	if runErr != nil {
 		log.Errorf("Run: %s", runErr)

--- a/step.go
+++ b/step.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	xcodebuildLogPath = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
+	xcodebuildLogPathEnvKey = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
+	xcodebuildLogBaseName   = "raw-xcodebuild-output.log"
 )
 
 const (
@@ -312,11 +313,11 @@ func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 	log.Infof("Export:")
 
 	if opts.XcodebuildLog != "" {
-		rawXcodebuildOutputLogPath := filepath.Join(opts.OutputDir, "raw-xcodebuild-output.log")
-		if err := output.ExportOutputFileContent(opts.XcodebuildLog, rawXcodebuildOutputLogPath, xcodebuildLogPath); err != nil {
-			log.Warnf("Failed to export %s, error: %s", xcodebuildLogPath, err)
+		xcodebuildLogPath := filepath.Join(opts.OutputDir, xcodebuildLogBaseName)
+		if err := output.ExportOutputFileContent(opts.XcodebuildLog, xcodebuildLogPath, xcodebuildLogPathEnvKey); err != nil {
+			log.Warnf("Failed to export %s, error: %s", xcodebuildLogPathEnvKey, err)
 		}
-		log.Donef("The xcodebuild command log file path is available in BITRISE_XCODE_RAW_RESULT_TEXT_PATH env: %s", rawXcodebuildOutputLogPath)
+		log.Donef("The xcodebuild command log file path is available in %s env: %s", xcodebuildLogPathEnvKey, xcodebuildLogPath)
 	}
 
 	if opts.BuiltTestDir == "" {

--- a/step.go
+++ b/step.go
@@ -246,7 +246,8 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 	}()
 
 	// Build for testing
-	log.Infof("Build:")
+	fmt.Println()
+	log.Infof("Running xcodebuild")
 
 	xcconfigWriter := xcconfig.NewWriter(v2pathutil.NewPathProvider(), v2fileutil.NewFileManager())
 	xcconfigPath, err := xcconfigWriter.Write(cfg.XCConfigContent)
@@ -285,6 +286,8 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 	}
 
 	// Find outputs
+	fmt.Println()
+	log.Infof("Searching for outputs")
 	testBundle, err := b.findTestBundle(findTestBundleOpts{
 		ProjectPath:       cfg.ProjectPath,
 		Scheme:            cfg.Scheme,
@@ -360,6 +363,8 @@ func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 }
 
 func (b TestBuilder) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
+	fmt.Println()
+
 	if codesignManager == nil {
 		log.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
 		return nil, nil

--- a/step.go
+++ b/step.go
@@ -140,7 +140,7 @@ func (b TestBuilder) ProcessConfig() (Config, error) {
 	if input.XcodebuildOptions != "" {
 		customOptions, err = shellquote.Split(input.XcodebuildOptions)
 		if err != nil {
-			return Config{}, fmt.Errorf("failed to parse additional options (%s): %w", input.XcodebuildOptions, err)
+			return Config{}, fmt.Errorf("provided additional options (%s) are not valid CLI arguments: %w", input.XcodebuildOptions, err)
 		}
 	}
 
@@ -309,7 +309,8 @@ type ExportOpts struct {
 }
 
 func (b TestBuilder) ExportOutput(opts ExportOpts) error {
-	log.Infof("Export:")
+	fmt.Println()
+	log.Infof("Export outputs")
 
 	if opts.XcodebuildLog != "" {
 		xcodebuildLogPath := filepath.Join(opts.OutputDir, xcodebuildLogBaseName)
@@ -343,7 +344,6 @@ func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 		}
 		return fmt.Errorf("%s failed: %w", zipCmd.PrintableCommandArgs(), err)
 	}
-	log.Printf("Zipped test bundle: %s", outputTestBundleZipPath)
 	if err := tools.ExportEnvironmentWithEnvman("BITRISE_TEST_BUNDLE_ZIP_PATH", outputTestBundleZipPath); err != nil {
 		return fmt.Errorf("failed to export BITRISE_TEST_BUNDLE_ZIP_PATH: %w", err)
 	}

--- a/step.go
+++ b/step.go
@@ -237,6 +237,13 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 	if err != nil {
 		return RunOut{}, err
 	}
+	defer func() {
+		if authOptions.KeyPath != "" {
+			if err := os.Remove(authOptions.KeyPath); err != nil {
+				log.Warnf("failed to remove private key file: %s", err)
+			}
+		}
+	}()
 
 	// Build for testing
 	log.Infof("Build:")
@@ -368,12 +375,6 @@ func (b TestBuilder) automaticCodeSigning(codesignManager *codesign.Manager) (*x
 		if err != nil {
 			return nil, err
 		}
-
-		defer func() {
-			if err := os.Remove(privateKey); err != nil {
-				log.Warnf("failed to remove private key file: %s", err)
-			}
-		}()
 
 		return &xcodebuild.AuthenticationParams{
 			KeyID:     xcodebuildAuthParams.KeyID,

--- a/step.go
+++ b/step.go
@@ -312,9 +312,11 @@ func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 	log.Infof("Export:")
 
 	if opts.XcodebuildLog != "" {
-		if err := exportXcodebuildTestLog(opts.OutputDir, opts.XcodebuildLog); err != nil {
-			return err
+		rawXcodebuildOutputLogPath := filepath.Join(opts.OutputDir, "raw-xcodebuild-output.log")
+		if err := output.ExportOutputFileContent(opts.XcodebuildLog, rawXcodebuildOutputLogPath, xcodebuildLogPath); err != nil {
+			log.Warnf("Failed to export %s, error: %s", xcodebuildLogPath, err)
 		}
+		log.Donef("The xcodebuild command log file path is available in BITRISE_XCODE_RAW_RESULT_TEXT_PATH env: %s", rawXcodebuildOutputLogPath)
 	}
 
 	if opts.BuiltTestDir == "" {

--- a/step.go
+++ b/step.go
@@ -273,7 +273,7 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 	// Cache swift packages
 	if cfg.CacheLevel == "swift_packages" {
 		if err := cache.CollectSwiftPackages(cfg.ProjectPath); err != nil {
-			log.Warnf("Failed to mark swift packages for caching, error: %s", err)
+			log.Warnf("Failed to mark swift packages for caching: %s", err)
 		}
 	}
 

--- a/step.go
+++ b/step.go
@@ -184,7 +184,6 @@ func (b TestBuilder) ProcessConfig() (Config, error) {
 	}, nil
 }
 
-// InstallDependencies ...
 func (b TestBuilder) InstallDependencies(useXCPretty bool) error {
 	if !useXCPretty {
 		return nil
@@ -417,7 +416,7 @@ func (b TestBuilder) findTestBundle(opts findTestBundleOpts) (testBundle, error)
 		return testBundle{}, fmt.Errorf("failed to read build settings: %w", err)
 	}
 
-	// The path at which all products will be placed when performing a build. Typically this path is not set per target, but is set per-project or per-user.
+	// The path at which all products will be placed when performing a build. Typically, this path is not set per target, but is set per-project or per-user.
 	symRoot, err := buildSettings.String("SYMROOT")
 	if err != nil {
 		return testBundle{}, fmt.Errorf("failed to get SYMROOT build setting: %w", err)

--- a/step.go
+++ b/step.go
@@ -297,18 +297,15 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 }
 
 type ExportOpts struct {
-	OutputDir         string
-	XcodebuildTestLog string
-	BuiltTestDir      string
-	XctestrunPth      string
-	SYMRoot           string
+	RunOut
+	OutputDir string
 }
 
 func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 	log.Infof("Export:")
 
-	if opts.XcodebuildTestLog != "" {
-		if err := exportXcodebuildTestLog(opts.OutputDir, opts.XcodebuildTestLog); err != nil {
+	if opts.XcodebuildLog != "" {
+		if err := exportXcodebuildTestLog(opts.OutputDir, opts.XcodebuildLog); err != nil {
 			return err
 		}
 	}

--- a/step.go
+++ b/step.go
@@ -1,0 +1,513 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/go-steputils/output"
+	"github.com/bitrise-io/go-steputils/tools"
+	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/colorstring"
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/stringutil"
+	v2command "github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	v2fileutil "github.com/bitrise-io/go-utils/v2/fileutil"
+	v2log "github.com/bitrise-io/go-utils/v2/log"
+	v2pathutil "github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/bitrise-io/go-xcode/utility"
+	"github.com/bitrise-io/go-xcode/v2/codesign"
+	"github.com/bitrise-io/go-xcode/v2/xcconfig"
+	"github.com/bitrise-io/go-xcode/v2/xcpretty"
+	"github.com/bitrise-io/go-xcode/xcodebuild"
+	cache "github.com/bitrise-io/go-xcode/xcodecache"
+	"github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace"
+	"github.com/kballard/go-shellquote"
+)
+
+const (
+	xcodebuildLogPath = "BITRISE_XCODE_RAW_RESULT_TEXT_PATH"
+
+	// Code Signing Authentication Source
+	codeSignSourceOff     = "off"
+	codeSignSourceAPIKey  = "api-key"
+	codeSignSourceAppleID = "apple-id"
+)
+
+// Input ...
+type Input struct {
+	ProjectPath       string `env:"project_path,required"`
+	Scheme            string `env:"scheme,required"`
+	Configuration     string `env:"configuration"`
+	Destination       string `env:"destination,required"`
+	XCConfigContent   string `env:"xcconfig_content"`
+	XcodebuildOptions string `env:"xcodebuild_options"`
+
+	LogFormatter string `env:"log_formatter,opt[xcpretty,xcodebuild]"`
+	OutputDir    string `env:"output_dir,required"`
+	CacheLevel   string `env:"cache_level,opt[none,swift_packages]"`
+	VerboseLog   bool   `env:"verbose_log,opt[yes,no]"`
+
+	CodeSigningAuthSource     string          `env:"automatic_code_signing,opt[off,api-key,apple-id]"`
+	CertificateURLList        string          `env:"certificate_url_list"`
+	CertificatePassphraseList stepconf.Secret `env:"passphrase_list"`
+	KeychainPath              string          `env:"keychain_path"`
+	KeychainPassword          stepconf.Secret `env:"keychain_password"`
+	RegisterTestDevices       bool            `env:"register_test_devices,opt[yes,no]"`
+	MinDaysProfileValid       int             `env:"min_profile_validity,required"`
+	TeamID                    string          `env:"apple_team_id"`
+	BuildURL                  string          `env:"BITRISE_BUILD_URL"`
+	BuildAPIToken             stepconf.Secret `env:"BITRISE_BUILD_API_TOKEN"`
+}
+
+type Config struct {
+	ProjectPath       string
+	Scheme            string
+	Configuration     string
+	Destination       string
+	XCConfigContent   string
+	XcodebuildOptions []string
+
+	XCPretty               bool
+	SwiftPackagesPath      string
+	OutputDir              string
+	XcodebuildMajorVersion int
+	CacheLevel             string
+	CodesignManager        *codesign.Manager
+}
+
+type TestBuilder struct {
+}
+
+func NewTestBuilder() TestBuilder {
+	return TestBuilder{}
+}
+
+func (b TestBuilder) ProcessConfig() (Config, error) {
+	var input Input
+	parser := stepconf.NewInputParser(env.NewRepository())
+	if err := parser.Parse(&input); err != nil {
+		return Config{}, err
+	}
+	logger := v2log.NewLogger()
+	logger.EnableDebugLog(input.VerboseLog)
+	log.SetEnableDebugLog(input.VerboseLog)
+
+	stepconf.Print(input)
+	fmt.Println()
+
+	absProjectPath, err := filepath.Abs(input.ProjectPath)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to expand ProjectPath (%s), error: %s", input.ProjectPath, err)
+	}
+
+	// abs out dir pth
+	absOutputDir, err := pathutil.AbsPath(input.OutputDir)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to expand OutputDir (%s), error: %s", input.OutputDir, err)
+	}
+
+	if exist, err := pathutil.IsPathExists(absOutputDir); err != nil {
+		return Config{}, fmt.Errorf("failed to check if OutputDir exist, error: %s", err)
+	} else if !exist {
+		if err := os.MkdirAll(absOutputDir, 0777); err != nil {
+			return Config{}, fmt.Errorf("failed to create OutputDir (%s), error: %s", absOutputDir, err)
+		}
+	}
+
+	// Detect Xcode major version
+	factory := v2command.NewFactory(env.NewRepository())
+	xcodebuildVersion, err := utility.GetXcodeVersion()
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to determin xcode version, error: %s", err)
+	}
+	log.Infof("Xcode version: %s (%s)", xcodebuildVersion.Version, xcodebuildVersion.BuildVersion)
+
+	var swiftPackagesPath string
+	if xcodebuildVersion.MajorVersion >= 11 {
+		var err error
+		if swiftPackagesPath, err = cache.SwiftPackagesPath(absProjectPath); err != nil {
+			return Config{}, fmt.Errorf("failed to get Swift Packages path, error: %s", err)
+		}
+	}
+
+	var customOptions []string
+	if input.XcodebuildOptions != "" {
+		customOptions, err = shellquote.Split(input.XcodebuildOptions)
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to shell split XcodebuildOptions (%s), error: %s", input.XcodebuildOptions, err)
+		}
+	}
+
+	var codesignManager *codesign.Manager = nil
+	if input.CodeSigningAuthSource != codeSignSourceOff {
+		codesignMgr, err := createCodesignManager(CodesignManagerOpts{
+			CodeSigningAuthSource:     input.CodeSigningAuthSource,
+			CertificateURLList:        input.CertificateURLList,
+			CertificatePassphraseList: input.CertificatePassphraseList,
+			KeychainPath:              input.KeychainPath,
+			KeychainPassword:          input.KeychainPassword,
+			BuildURL:                  input.BuildURL,
+			BuildAPIToken:             input.BuildAPIToken,
+			TeamID:                    input.TeamID,
+			RegisterTestDevices:       input.RegisterTestDevices,
+			MinDaysProfileValid:       input.MinDaysProfileValid,
+			VerboseLog:                input.VerboseLog,
+			ProjectPath:               absProjectPath,
+			Scheme:                    input.Scheme,
+			Configuration:             input.Configuration,
+		}, xcodebuildVersion.MajorVersion, logger, factory)
+		if err != nil {
+			return Config{}, err
+		}
+		codesignManager = &codesignMgr
+	}
+
+	return Config{
+		XCPretty:          input.LogFormatter == "xcpretty",
+		CodesignManager:   codesignManager,
+		SwiftPackagesPath: swiftPackagesPath,
+		OutputDir:         absOutputDir,
+
+		ProjectPath:       absProjectPath,
+		Scheme:            input.Scheme,
+		Configuration:     input.Configuration,
+		Destination:       input.Destination,
+		XcodebuildOptions: customOptions,
+		XCConfigContent:   input.XCConfigContent,
+
+		XcodebuildMajorVersion: int(xcodebuildVersion.MajorVersion),
+		CacheLevel:             input.CacheLevel,
+	}, nil
+}
+
+// InstallDependencies ...
+func (b TestBuilder) InstallDependencies(useXCPretty bool) error {
+	if !useXCPretty {
+		return nil
+	}
+
+	fmt.Println()
+	log.Infof("Checking if log formatter (xcpretty) is installed")
+
+	var xcpretty = xcpretty.NewXcpretty()
+
+	installed, err := xcpretty.IsInstalled()
+	if err != nil {
+		return fmt.Errorf("failed to check if xcpretty is installed, error: %s", err)
+	} else if !installed {
+		log.Warnf(`xcpretty is not installed`)
+		fmt.Println()
+		log.Printf("Installing xcpretty")
+
+		cmds, err := xcpretty.Install()
+		if err != nil {
+			return fmt.Errorf("failed to create xcpretty install command: %s", err)
+		}
+
+		for _, cmd := range cmds {
+			if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+				if errorutil.IsExitStatusError(err) {
+					return fmt.Errorf("%s failed: %s", cmd.PrintableCommandArgs(), out)
+				}
+				return fmt.Errorf("%s failed: %s", cmd.PrintableCommandArgs(), err)
+			}
+		}
+
+	}
+
+	xcprettyVersion, err := xcpretty.Version()
+	if err != nil {
+		return fmt.Errorf("failed to determine xcpretty version, error: %s", err)
+	}
+	log.Printf("- xcprettyVersion: %s", xcprettyVersion.String())
+
+	return nil
+}
+
+// RunOpts ...
+type RunOpts struct {
+	XCPretty          bool
+	CodesignManager   *codesign.Manager
+	SwiftPackagesPath string
+	OutputDir         string
+
+	ProjectPath       string
+	Scheme            string
+	Configuration     string
+	Destination       string
+	XCConfigContent   string
+	XcodebuildOptions []string
+}
+
+// RunOut ...
+type RunOut struct {
+	BuildInterval timeInterval
+	XcodebuildLog string
+}
+
+// Run ...
+func (b TestBuilder) Run(opts RunOpts) (RunOut, error) {
+	//
+	// Manage code signing
+	var authOptions *xcodebuild.AuthenticationParams = nil
+	if opts.CodesignManager != nil {
+		log.Infof("Preparing code signing assets (certificates, profiles)")
+
+		xcodebuildAuthParams, err := opts.CodesignManager.PrepareCodesigning()
+		if err != nil {
+			return RunOut{}, fmt.Errorf("failed to prepare code signing assets: %s", err)
+		}
+
+		if xcodebuildAuthParams != nil {
+			privateKey, err := xcodebuildAuthParams.WritePrivateKeyToFile()
+			if err != nil {
+				return RunOut{}, err
+			}
+
+			defer func() {
+				if err := os.Remove(privateKey); err != nil {
+					log.Warnf("failed to remove private key file: %s", err)
+				}
+			}()
+
+			authOptions = &xcodebuild.AuthenticationParams{
+				KeyID:     xcodebuildAuthParams.KeyID,
+				IsssuerID: xcodebuildAuthParams.IssuerID,
+				KeyPath:   privateKey,
+			}
+		}
+	} else {
+		log.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
+	}
+
+	//
+	// Build
+	log.Infof("Build:")
+
+	xcconfigWriter := xcconfig.NewWriter(v2pathutil.NewPathProvider(), v2fileutil.NewFileManager())
+	xcconfigPath, err := xcconfigWriter.Write(opts.XCConfigContent)
+	if err != nil {
+		return RunOut{}, err
+	}
+
+	xcodeBuildCmd := xcodebuild.NewCommandBuilder(opts.ProjectPath, xcworkspace.IsWorkspace(opts.ProjectPath), "")
+	xcodeBuildCmd.SetScheme(opts.Scheme)
+	xcodeBuildCmd.SetConfiguration(opts.Configuration)
+	xcodeBuildCmd.SetCustomBuildAction("build-for-testing")
+	xcodeBuildCmd.SetDestination(opts.Destination)
+	xcodeBuildCmd.SetCustomOptions(opts.XcodebuildOptions)
+	xcodeBuildCmd.SetXCConfigPath(xcconfigPath)
+	if authOptions != nil {
+		xcodeBuildCmd.SetAuthentication(*authOptions)
+	}
+
+	// save the build time frame to find the build generated artifacts
+	rawXcodebuildOut, buildInterval, err := runCommandWithRetry(xcodeBuildCmd, opts.XCPretty, opts.SwiftPackagesPath)
+	if err != nil || !opts.XCPretty {
+		printLastLinesOfXcodebuildTestLog(rawXcodebuildOut, err == nil)
+	}
+
+	return RunOut{
+		BuildInterval: buildInterval,
+		XcodebuildLog: rawXcodebuildOut,
+	}, nil
+}
+
+// ExportOpts ...
+type ExportOpts struct {
+	OutputDir         string
+	ProjectPath       string
+	Scheme            string
+	Configuration     string
+	XcodebuildOptions []string
+	BuildInterval     timeInterval
+	CacheLevel        string
+	XcodebuildTestLog string
+}
+
+// ExportOutput ...
+func (b TestBuilder) ExportOutput(opts ExportOpts) error {
+	log.Infof("Export:")
+
+	if opts.XcodebuildTestLog != "" {
+		if err := exportXcodebuildTestLog(opts.OutputDir, opts.XcodebuildTestLog); err != nil {
+			return err
+		}
+	}
+
+	buildSettingsCmd := xcodebuild.NewShowBuildSettingsCommand(opts.ProjectPath)
+	buildSettingsCmd.SetScheme(opts.Scheme)
+	buildSettingsCmd.SetConfiguration(opts.Configuration)
+	buildSettingsCmd.SetCustomOptions(append([]string{"build-for-testing"}, opts.XcodebuildOptions...))
+
+	fmt.Println()
+	log.Donef("$ %s", buildSettingsCmd.PrintableCmd())
+
+	buildSettings, err := buildSettingsCmd.RunAndReturnSettings()
+	if err != nil {
+		return fmt.Errorf("failed to read build settings: %s", err)
+	}
+
+	// The path at which all products will be placed when performing a build. Typically this path is not set per target, but is set per-project or per-user.
+	symRoot, err := buildSettings.String("SYMROOT")
+	if err != nil {
+		return fmt.Errorf("failed to parse SYMROOT build setting: %s", err)
+	}
+	log.Printf("SYMROOT: %s", symRoot)
+
+	configuration, err := buildSettings.String("CONFIGURATION")
+	if err != nil {
+		return fmt.Errorf("failed to parse CONFIGURATION build setting: %s", err)
+	}
+	log.Printf("CONFIGURATION: %s", configuration)
+
+	// Without better solution the step collects every xctestrun files and filters them for the build time frame
+	xctestrunPthPattern := filepath.Join(symRoot, fmt.Sprintf("%s*.xctestrun", opts.Scheme))
+	xctestrunPths, err := filepath.Glob(xctestrunPthPattern)
+	if err != nil {
+		return fmt.Errorf("failed to search for xctestrun file using pattern: %s, error: %s", xctestrunPthPattern, err)
+	}
+	log.Printf("xctestrun paths: %s", strings.Join(xctestrunPths, ", "))
+
+	if len(xctestrunPths) == 0 {
+		return fmt.Errorf("no xctestrun file found with pattern: %s", xctestrunPthPattern)
+	}
+
+	var buildXCTestrunPths []string
+	for _, xctestrunPth := range xctestrunPths {
+		info, err := os.Stat(xctestrunPth)
+		if err != nil {
+			return fmt.Errorf("failed to check %s modtime: %s", xctestrunPth, err)
+		}
+
+		if !info.ModTime().Before(opts.BuildInterval.start) && !info.ModTime().After(opts.BuildInterval.end) {
+			buildXCTestrunPths = append(buildXCTestrunPths, xctestrunPth)
+		}
+	}
+
+	if len(buildXCTestrunPths) == 0 {
+		return fmt.Errorf("no xctestrun file generated during the build")
+	} else if len(buildXCTestrunPths) > 1 {
+		return fmt.Errorf("multiple xctestrun file generated during the build:\n%s", strings.Join(buildXCTestrunPths, "\n- "))
+	}
+
+	xctestrunPth := buildXCTestrunPths[0]
+	log.Printf("Built xctestrun path: %s", xctestrunPth)
+
+	// Without better solution the step determines the build target based on the xctestrun file name
+	// ios-simple-objc_iphonesimulator12.0-x86_64.xctestrun
+	var builtForDestination string
+	if strings.Contains(xctestrunPth, fmt.Sprintf("%s_iphonesimulator", opts.Scheme)) {
+		builtForDestination = "iphonesimulator"
+	} else {
+		builtForDestination = "iphoneos"
+	}
+
+	builtTestDir := filepath.Join(symRoot, fmt.Sprintf("%s-%s", configuration, builtForDestination))
+	if exist, err := pathutil.IsPathExists(builtTestDir); err != nil {
+		return fmt.Errorf("failed to check if built test directory exists at: %s, error: %s", builtTestDir, err)
+	} else if !exist {
+		return fmt.Errorf("built test directory does not exist at: %s", builtTestDir)
+	}
+	log.Printf("Built test directory: %s", builtTestDir)
+
+	outputTestBundleZipPath := filepath.Join(opts.OutputDir, "testbundle.zip")
+	factory := v2command.NewFactory(env.NewRepository())
+	zipCmd := factory.Create("zip", []string{"-r", outputTestBundleZipPath, filepath.Base(builtTestDir), filepath.Base(xctestrunPth)}, &v2command.Opts{
+		Dir: symRoot,
+	})
+	if out, err := zipCmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+		if errorutil.IsExitStatusError(err) {
+			return fmt.Errorf("%s failed: %s", zipCmd.PrintableCommandArgs(), out)
+		} else {
+			return fmt.Errorf("%s failed: %s", zipCmd.PrintableCommandArgs(), err)
+		}
+	}
+	log.Printf("Zipped test bundle: %s", outputTestBundleZipPath)
+
+	outputXCTestrunPth := filepath.Join(opts.OutputDir, filepath.Base(xctestrunPth))
+	if err := output.ExportOutputFile(xctestrunPth, outputXCTestrunPth, "BITRISE_XCTESTRUN_FILE_PATH"); err != nil {
+		return fmt.Errorf("failed to export BITRISE_XCTESTRUN_FILE_PATH: %s", err)
+	}
+	log.Donef("The built xctestrun file is available in BITRISE_XCTESTRUN_FILE_PATH env: %s", outputXCTestrunPth)
+
+	outputTestDirPath := filepath.Join(opts.OutputDir, filepath.Base(builtTestDir))
+	if err := output.ExportOutputDir(builtTestDir, outputTestDirPath, "BITRISE_TEST_DIR_PATH"); err != nil {
+		return fmt.Errorf("failed to export BITRISE_TEST_DIR_PATH: %s", err)
+	}
+	log.Donef("The built test directory is available in BITRISE_TEST_DIR_PATH env: %s", outputTestDirPath)
+
+	if err := tools.ExportEnvironmentWithEnvman("BITRISE_TEST_BUNDLE_ZIP_PATH", outputTestBundleZipPath); err != nil {
+		return fmt.Errorf("failed to export BITRISE_TEST_BUNDLE_ZIP_PATH: %s", err)
+	}
+
+	// Cache swift PM
+	if opts.CacheLevel == "swift_packages" {
+		if err := cache.CollectSwiftPackages(opts.ProjectPath); err != nil {
+			log.Warnf("Failed to mark swift packages for caching, error: %s", err)
+		}
+	}
+
+	log.Donef("The zipped test bundle is available in BITRISE_TEST_BUNDLE_ZIP_PATH env: %s", outputTestBundleZipPath)
+	return nil
+}
+
+func printLastLinesOfXcodebuildTestLog(rawXcodebuildOutput string, isRunSuccess bool) {
+	const lastLines = "\nLast lines of the build log:"
+	if !isRunSuccess {
+		log.Errorf(lastLines)
+	} else {
+		log.Infof(lastLines)
+	}
+
+	fmt.Println(stringutil.LastNLines(rawXcodebuildOutput, 20))
+
+	if !isRunSuccess {
+		log.Warnf("If you can't find the reason of the error in the log, please check the xcodebuild_test.log.")
+	}
+
+	log.Infof(colorstring.Magenta(`
+The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
+is available in the $BITRISE_XCODEBUILD_TEST_LOG_PATH environment variable.
+If you have the Deploy to Bitrise.io step (after this step),
+that will attach the file to your build as an artifact!`))
+}
+
+func exportXcodebuildTestLog(deployDir, xcodebuildTestLog string) error {
+	pth, err := saveRawOutputToLogFile(xcodebuildTestLog)
+	if err != nil {
+		log.Warnf("Failed to save the Raw Output, error: %s", err)
+	}
+
+	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")
+	if err := command.CopyFile(pth, deployPth); err != nil {
+		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s), error: %s", pth, deployPth, err)
+	}
+
+	if err := tools.ExportEnvironmentWithEnvman(xcodebuildLogPath, deployPth); err != nil {
+		log.Warnf("Failed to export: %s, error: %s", xcodebuildLogPath, err)
+	}
+
+	return nil
+}
+
+func saveRawOutputToLogFile(rawXcodebuildOutput string) (string, error) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("xcodebuild-output")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir, error: %s", err)
+	}
+	logFileName := "raw-xcodebuild-output.log"
+	logPth := filepath.Join(tmpDir, logFileName)
+	if err := fileutil.WriteStringToFile(logPth, rawXcodebuildOutput); err != nil {
+		return "", fmt.Errorf("failed to write xcodebuild output to file, error: %s", err)
+	}
+
+	return logPth, nil
+}

--- a/step.go
+++ b/step.go
@@ -239,7 +239,7 @@ func (b TestBuilder) Run(cfg Config) (RunOut, error) {
 		return RunOut{}, err
 	}
 	defer func() {
-		if authOptions.KeyPath != "" {
+		if authOptions != nil && authOptions.KeyPath != "" {
 			if err := os.Remove(authOptions.KeyPath); err != nil {
 				log.Warnf("failed to remove private key file: %s", err)
 			}

--- a/utils.go
+++ b/utils.go
@@ -37,7 +37,7 @@ that will attach the file to your build as an artifact!`))
 func exportXcodebuildTestLog(deployDir, xcodebuildTestLog string) error {
 	pth, err := saveRawOutputToLogFile(xcodebuildTestLog)
 	if err != nil {
-		log.Warnf("Failed to save the Raw Output, error: %s", err)
+		log.Warnf("Failed to save the xcodebuild log: %s", err)
 	}
 
 	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")

--- a/utils.go
+++ b/utils.go
@@ -19,12 +19,12 @@ func printLastLinesOfXcodebuildTestLog(rawXcodebuildOutput string, isRunSuccess 
 	fmt.Println(stringutil.LastNLines(rawXcodebuildOutput, 20))
 
 	if !isRunSuccess {
-		log.Warnf("If you can't find the reason of the error in the log, please check the xcodebuild_test.log.")
+		log.Warnf("If you can't find the reason of the error in the log, please check the %s.", xcodebuildLogBaseName)
 	}
 
-	log.Infof(colorstring.Magenta(`
-The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
-is available in the $BITRISE_XCODEBUILD_TEST_LOG_PATH environment variable.
-If you have the Deploy to Bitrise.io step (after this step),
-that will attach the file to your build as an artifact!`))
+	fmt.Println(colorstring.Magentaf(`
+The log file is stored in the output directory, and its full path
+is available in the $%s environment variable.
+Use Deploy to Bitrise.io step (after this step),
+to attach the file to your build as an artifact!`, xcodebuildLogPathEnvKey))
 }

--- a/utils.go
+++ b/utils.go
@@ -2,14 +2,9 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
-	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-utils/colorstring"
-	"github.com/bitrise-io/go-utils/command"
-	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/stringutil"
 )
 
@@ -32,36 +27,4 @@ The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
 is available in the $BITRISE_XCODEBUILD_TEST_LOG_PATH environment variable.
 If you have the Deploy to Bitrise.io step (after this step),
 that will attach the file to your build as an artifact!`))
-}
-
-func exportXcodebuildTestLog(deployDir, xcodebuildTestLog string) error {
-	pth, err := saveRawOutputToLogFile(xcodebuildTestLog)
-	if err != nil {
-		log.Warnf("Failed to save the xcodebuild log: %s", err)
-	}
-
-	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")
-	if err := command.CopyFile(pth, deployPth); err != nil {
-		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s): %w", pth, deployPth, err)
-	}
-
-	if err := tools.ExportEnvironmentWithEnvman(xcodebuildLogPath, deployPth); err != nil {
-		log.Warnf("Failed to export: %s: %s", xcodebuildLogPath, err)
-	}
-
-	return nil
-}
-
-func saveRawOutputToLogFile(rawXcodebuildOutput string) (string, error) {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("xcodebuild-output")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
-	}
-	logFileName := "raw-xcodebuild-output.log"
-	logPth := filepath.Join(tmpDir, logFileName)
-	if err := fileutil.WriteStringToFile(logPth, rawXcodebuildOutput); err != nil {
-		return "", fmt.Errorf("failed to write xcodebuild output to file: %w", err)
-	}
-
-	return logPth, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-steputils/tools"
+	"github.com/bitrise-io/go-utils/colorstring"
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/stringutil"
+)
+
+func printLastLinesOfXcodebuildTestLog(rawXcodebuildOutput string, isRunSuccess bool) {
+	const lastLines = "\nLast lines of the build log:"
+	if !isRunSuccess {
+		log.Errorf(lastLines)
+	} else {
+		log.Infof(lastLines)
+	}
+
+	fmt.Println(stringutil.LastNLines(rawXcodebuildOutput, 20))
+
+	if !isRunSuccess {
+		log.Warnf("If you can't find the reason of the error in the log, please check the xcodebuild_test.log.")
+	}
+
+	log.Infof(colorstring.Magenta(`
+The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
+is available in the $BITRISE_XCODEBUILD_TEST_LOG_PATH environment variable.
+If you have the Deploy to Bitrise.io step (after this step),
+that will attach the file to your build as an artifact!`))
+}
+
+func exportXcodebuildTestLog(deployDir, xcodebuildTestLog string) error {
+	pth, err := saveRawOutputToLogFile(xcodebuildTestLog)
+	if err != nil {
+		log.Warnf("Failed to save the Raw Output, error: %s", err)
+	}
+
+	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")
+	if err := command.CopyFile(pth, deployPth); err != nil {
+		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s): %w", pth, deployPth, err)
+	}
+
+	if err := tools.ExportEnvironmentWithEnvman(xcodebuildLogPath, deployPth); err != nil {
+		log.Warnf("Failed to export: %s: %s", xcodebuildLogPath, err)
+	}
+
+	return nil
+}
+
+func saveRawOutputToLogFile(rawXcodebuildOutput string) (string, error) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("xcodebuild-output")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	logFileName := "raw-xcodebuild-output.log"
+	logPth := filepath.Join(tmpDir, logFileName)
+	if err := fileutil.WriteStringToFile(logPth, rawXcodebuildOutput); err != nil {
+		return "", fmt.Errorf("failed to write xcodebuild output to file: %w", err)
+	}
+
+	return logPth, nil
+}

--- a/vendor/github.com/bitrise-io/go-xcode/v2/xcodebuild/xcodebuild.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/xcodebuild/xcodebuild.go
@@ -1,0 +1,9 @@
+package xcodebuild
+
+import "github.com/bitrise-io/go-utils/v2/command"
+
+// CommandModel ...
+type CommandModel interface {
+	PrintableCmd() string
+	Command(opts *command.Opts) command.Command
+}

--- a/vendor/github.com/bitrise-io/go-xcode/v2/xcpretty/xcpretty.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/xcpretty/xcpretty.go
@@ -1,0 +1,150 @@
+package xcpretty
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/bitrise-io/go-steputils/v2/ruby"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-xcode/v2/xcodebuild"
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	toolName = "xcpretty"
+)
+
+// CommandModel ...
+type CommandModel struct {
+	xcodebuildCommand xcodebuild.CommandModel
+	customOptions     []string
+}
+
+// New ...
+func New(xcodebuildCommand xcodebuild.CommandModel) *CommandModel {
+	return &CommandModel{
+		xcodebuildCommand: xcodebuildCommand,
+	}
+}
+
+// SetCustomOptions ...
+func (c *CommandModel) SetCustomOptions(customOptions []string) *CommandModel {
+	c.customOptions = customOptions
+	return c
+}
+
+// Command ...
+func (c CommandModel) Command(opts *command.Opts) command.Command {
+	return command.NewFactory(env.NewRepository()).Create(toolName, c.customOptions, opts)
+}
+
+// PrintableCmd ...
+func (c CommandModel) PrintableCmd() string {
+	prettyCmdStr := c.Command(nil).PrintableCommandArgs()
+	xcodebuildCmdStr := c.xcodebuildCommand.PrintableCmd()
+
+	return fmt.Sprintf("set -o pipefail && %s | %s", xcodebuildCmdStr, prettyCmdStr)
+}
+
+// Run ...
+func (c CommandModel) Run() (string, error) {
+
+	// Configure cmd in- and outputs
+	pipeReader, pipeWriter := io.Pipe()
+
+	var outBuffer bytes.Buffer
+	outWriter := io.MultiWriter(&outBuffer, pipeWriter)
+
+	xcodebuildCmd := c.xcodebuildCommand.Command(&command.Opts{
+		Stdin:  nil,
+		Stdout: outWriter,
+		Stderr: outWriter,
+	})
+
+	prettyCmd := c.Command(&command.Opts{
+		Stdin:  pipeReader,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+
+	// Run
+	if err := xcodebuildCmd.Start(); err != nil {
+		out := outBuffer.String()
+		return out, err
+	}
+	if err := prettyCmd.Start(); err != nil {
+		out := outBuffer.String()
+		return out, err
+	}
+
+	// Always close xcpretty outputs
+	defer func() {
+		if err := pipeWriter.Close(); err != nil {
+			log.Warnf("Failed to close xcodebuild-xcpretty pipe, error: %s", err)
+		}
+
+		if err := prettyCmd.Wait(); err != nil {
+			log.Warnf("xcpretty command failed, error: %s", err)
+		}
+	}()
+
+	if err := xcodebuildCmd.Wait(); err != nil {
+		out := outBuffer.String()
+		return out, err
+	}
+
+	return outBuffer.String(), nil
+}
+
+// Xcpretty ...
+type Xcpretty interface {
+	IsInstalled() (bool, error)
+	Install() ([]command.Command, error)
+	Version() (*version.Version, error)
+}
+
+type xcpretty struct {
+}
+
+// NewXcpretty ...
+func NewXcpretty() Xcpretty {
+	return &xcpretty{}
+}
+
+func (x xcpretty) IsInstalled() (bool, error) {
+	locator := env.NewCommandLocator()
+	factory, err := ruby.NewCommandFactory(command.NewFactory(env.NewRepository()), locator)
+	if err != nil {
+		return false, err
+	}
+
+	return ruby.NewEnvironment(factory, locator).IsGemInstalled("xcpretty", "")
+}
+
+// Install ...
+func (x xcpretty) Install() ([]command.Command, error) {
+	locator := env.NewCommandLocator()
+	factory, err := ruby.NewCommandFactory(command.NewFactory(env.NewRepository()), locator)
+	if err != nil {
+		return nil, err
+	}
+
+	cmds := factory.CreateGemInstall("xcpretty", "", false, false, nil)
+
+	return cmds, nil
+}
+
+// Version ...
+func (x xcpretty) Version() (*version.Version, error) {
+	cmd := command.NewFactory(env.NewRepository()).Create("xcpretty", []string{"--version"}, nil)
+	versionOut, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return version.NewVersion(versionOut)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,6 +70,8 @@ github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager
 github.com/bitrise-io/go-xcode/v2/codesign
 github.com/bitrise-io/go-xcode/v2/xcarchive
 github.com/bitrise-io/go-xcode/v2/xcconfig
+github.com/bitrise-io/go-xcode/v2/xcodebuild
+github.com/bitrise-io/go-xcode/v2/xcpretty
 # github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8
 ## explicit
 github.com/bitrise-io/pkcs12


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

(Minor version due to the [substantial improvements within the private code](https://semver.org/#spec-item-7))

### Context

This PR updates the Step's error messages, to achieve it easily, the Step got a partial ideal Step refactor too.

### Changes

- Top-level input parsing errors got a new format: `Process config: %s`
- Top-level step dependency installation warning got a new format: `Install dependencies: %s`
- Top-level step run errors got a new format: `Run: %s`
- Top-level step dependency install got a new format: `Export outputs: %s`
- Improved error messages
  - removed `, error: ` suffixes from error messages
  - use `%w` for wrapping errors

Non-functional changes:
- Partial Ideal Step refactor:
  - main function is split into: `TestBuilder.ProcessConfig`, `TestBuilder.InstallDependencies`, `TestBuilder.Run` and `TestBuilder.ExportOutput`
  - the step's functionality is moved to step.go, main.go contains only glue code
