### PR TITLE
Added equals comparison for result file mod time.

### DIFF
--- a/step.go
+++ b/step.go
@@ -452,8 +452,10 @@ func (b TestBuilder) findTestBundle(opts findTestBundleOpts) (testBundle, error)
 		if err != nil {
 			return testBundle{}, fmt.Errorf("failed to check %s modtime: %w", xctestrunPth, err)
 		}
-
-		if !info.ModTime().Before(opts.BuildInterval.start) && !info.ModTime().After(opts.BuildInterval.end) {
+		buildStartTime := opts.BuildInterval.start
+		buildEndTime := opts.BuildInterval.end
+		if (info.ModTime().After(buildStartTime) && info.ModTime().Before(buildEndTime)) ||
+			info.ModTime().Equal(buildStartTime) || info.ModTime().Equal(buildEndTime) {
 			buildXCTestrunPths = append(buildXCTestrunPths, xctestrunPth)
 		}
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Build intermittently experiences an error with the Xcode Build for Test step.
https://app.bitrise.io/build/d139b0d7-a76e-4a16-8f5b-fdce88355202

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes
Added equals comparison; inverted existing logic to test for positive cases to improve readability.
<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details
The failing builds are intermittent and emit the error message "no xctestrun file generated during the build". After inspecting the code, it appears that the original time comparison omits the small possibility that the ModTime of the xctestrun file is equal to the start or ent time of the run. 

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
