### PR TITLE
Reverted to more concise time check; added logs to better surface failure reasons.

### DIFF
--- a/step.go
+++ b/step.go
@@ -454,9 +454,10 @@ func (b TestBuilder) findTestBundle(opts findTestBundleOpts) (testBundle, error)
 		}
 		buildStartTime := opts.BuildInterval.start
 		buildEndTime := opts.BuildInterval.end
-		if (info.ModTime().After(buildStartTime) && info.ModTime().Before(buildEndTime)) ||
-			info.ModTime().Equal(buildStartTime) || info.ModTime().Equal(buildEndTime) {
+		if !info.ModTime().Before(buildStartTime) && !info.ModTime().After(buildEndTime) {
 			buildXCTestrunPths = append(buildXCTestrunPths, xctestrunPth)
+		} else {
+			log.Printf("xctestrun: %s was created at %s, which is outside of the window %s - %s ", xctestrunPth, info.ModTime(), buildStartTime, buildEndTime)
 		}
 	}
 


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context
After more conversation around #34 we decided that we should start by adding more logging in order to better understand this failure mode. 
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes
Reverted to original, more concise time comparison; added logging to describe the reason that comparison failed. 
<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
