### PR TITLE
[PLANG-1721] Move Step logic to the step package

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ func run() int {
 	exitCode := 0
 
 	logger := log.NewLogger()
-	xcodebuildBuild := createXcodebuildBuild(logger)
+	xcodebuildBuilder := createXcodebuildBuilder(logger)
 
-	cfg, err := xcodebuildBuild.ProcessConfig()
+	cfg, err := xcodebuildBuilder.ProcessConfig()
 	if err != nil {
 		logger.Errorf("Process config: %s", err)
 
@@ -25,19 +25,19 @@ func run() int {
 		return exitCode
 	}
 
-	if err := xcodebuildBuild.InstallDependencies(cfg.XCPretty); err != nil {
+	if err := xcodebuildBuilder.InstallDependencies(cfg.XCPretty); err != nil {
 		logger.Warnf("Install dependencies: %s", err)
 		logger.Printf("Switching to xcodebuild for output tool")
 		cfg.XCPretty = false
 	}
 
-	result, err := xcodebuildBuild.Run(cfg)
+	result, err := xcodebuildBuilder.Run(cfg)
 	if err != nil {
 		logger.Errorf("Run: %s", err)
 		exitCode = 1
 	}
 
-	if err := xcodebuildBuild.ExportOutputs(step.ExportOpts{
+	if err := xcodebuildBuilder.ExportOutputs(step.ExportOpts{
 		OutputDir: cfg.OutputDir,
 		RunOut:    result,
 	}); err != nil {
@@ -48,6 +48,6 @@ func run() int {
 	return exitCode
 }
 
-func createXcodebuildBuild(logger log.Logger) step.XcodebuildBuild {
-	return step.NewXcodebuildBuild(logger)
+func createXcodebuildBuilder(logger log.Logger) step.XcodebuildBuilder {
+	return step.NewXcodebuildBuilder(logger)
 }

--- a/step/build.go
+++ b/step/build.go
@@ -1,4 +1,4 @@
-package main
+package step
 
 import (
 	"bytes"

--- a/step/codesign.go
+++ b/step/codesign.go
@@ -1,4 +1,4 @@
-package main
+package step
 
 import (
 	"fmt"

--- a/step/step.go
+++ b/step/step.go
@@ -1,4 +1,4 @@
-package main
+package step
 
 import (
 	"errors"
@@ -84,17 +84,17 @@ type Config struct {
 	SwiftPackagesPath      string
 }
 
-type TestBuilder struct {
+type XcodebuildBuild struct {
 	logger v2log.Logger
 }
 
-func NewTestBuilder(logger v2log.Logger) TestBuilder {
-	return TestBuilder{
+func NewXcodebuildBuild(logger v2log.Logger) XcodebuildBuild {
+	return XcodebuildBuild{
 		logger: logger,
 	}
 }
 
-func (b TestBuilder) ProcessConfig() (Config, error) {
+func (b XcodebuildBuild) ProcessConfig() (Config, error) {
 	var input Input
 	parser := stepconf.NewInputParser(env.NewRepository())
 	if err := parser.Parse(&input); err != nil {
@@ -195,7 +195,7 @@ func (b TestBuilder) ProcessConfig() (Config, error) {
 	}, nil
 }
 
-func (b TestBuilder) InstallDependencies(useXCPretty bool) error {
+func (b XcodebuildBuild) InstallDependencies(useXCPretty bool) error {
 	if !useXCPretty {
 		return nil
 	}
@@ -242,7 +242,7 @@ type RunOut struct {
 	SYMRoot       string
 }
 
-func (b TestBuilder) Run(cfg Config) (RunOut, error) {
+func (b XcodebuildBuild) Run(cfg Config) (RunOut, error) {
 	// Automatic code signing
 	authOptions, err := b.automaticCodeSigning(cfg.CodesignManager)
 	if err != nil {
@@ -325,7 +325,7 @@ type ExportOpts struct {
 	OutputDir string
 }
 
-func (b TestBuilder) ExportOutput(opts ExportOpts) error {
+func (b XcodebuildBuild) ExportOutputs(opts ExportOpts) error {
 	b.logger.Println()
 	b.logger.Infof("Export outputs")
 
@@ -376,8 +376,7 @@ func (b TestBuilder) ExportOutput(opts ExportOpts) error {
 	return nil
 }
 
-func (b TestBuilder) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
-	b.logger.Println()
+func (b XcodebuildBuild) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
 
 	if codesignManager == nil {
 		b.logger.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
@@ -421,7 +420,7 @@ type testBundle struct {
 	SYMRoot      string
 }
 
-func (b TestBuilder) findTestBundle(opts findTestBundleOpts) (testBundle, error) {
+func (b XcodebuildBuild) findTestBundle(opts findTestBundleOpts) (testBundle, error) {
 	buildSettingsCmd := xcodebuild.NewShowBuildSettingsCommand(opts.ProjectPath)
 	buildSettingsCmd.SetScheme(opts.Scheme)
 	buildSettingsCmd.SetConfiguration(opts.Configuration)

--- a/step/step.go
+++ b/step/step.go
@@ -84,17 +84,17 @@ type Config struct {
 	SwiftPackagesPath      string
 }
 
-type XcodebuildBuild struct {
+type XcodebuildBuilder struct {
 	logger v2log.Logger
 }
 
-func NewXcodebuildBuild(logger v2log.Logger) XcodebuildBuild {
-	return XcodebuildBuild{
+func NewXcodebuildBuilder(logger v2log.Logger) XcodebuildBuilder {
+	return XcodebuildBuilder{
 		logger: logger,
 	}
 }
 
-func (b XcodebuildBuild) ProcessConfig() (Config, error) {
+func (b XcodebuildBuilder) ProcessConfig() (Config, error) {
 	var input Input
 	parser := stepconf.NewInputParser(env.NewRepository())
 	if err := parser.Parse(&input); err != nil {
@@ -195,7 +195,7 @@ func (b XcodebuildBuild) ProcessConfig() (Config, error) {
 	}, nil
 }
 
-func (b XcodebuildBuild) InstallDependencies(useXCPretty bool) error {
+func (b XcodebuildBuilder) InstallDependencies(useXCPretty bool) error {
 	if !useXCPretty {
 		return nil
 	}
@@ -242,7 +242,7 @@ type RunOut struct {
 	SYMRoot       string
 }
 
-func (b XcodebuildBuild) Run(cfg Config) (RunOut, error) {
+func (b XcodebuildBuilder) Run(cfg Config) (RunOut, error) {
 	// Automatic code signing
 	authOptions, err := b.automaticCodeSigning(cfg.CodesignManager)
 	if err != nil {
@@ -325,7 +325,7 @@ type ExportOpts struct {
 	OutputDir string
 }
 
-func (b XcodebuildBuild) ExportOutputs(opts ExportOpts) error {
+func (b XcodebuildBuilder) ExportOutputs(opts ExportOpts) error {
 	b.logger.Println()
 	b.logger.Infof("Export outputs")
 
@@ -376,7 +376,7 @@ func (b XcodebuildBuild) ExportOutputs(opts ExportOpts) error {
 	return nil
 }
 
-func (b XcodebuildBuild) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
+func (b XcodebuildBuilder) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
 	b.logger.Println()
 
 	if codesignManager == nil {
@@ -421,7 +421,7 @@ type testBundle struct {
 	SYMRoot      string
 }
 
-func (b XcodebuildBuild) findTestBundle(opts findTestBundleOpts) (testBundle, error) {
+func (b XcodebuildBuilder) findTestBundle(opts findTestBundleOpts) (testBundle, error) {
 	buildSettingsCmd := xcodebuild.NewShowBuildSettingsCommand(opts.ProjectPath)
 	buildSettingsCmd.SetScheme(opts.Scheme)
 	buildSettingsCmd.SetConfiguration(opts.Configuration)

--- a/step/step.go
+++ b/step/step.go
@@ -14,9 +14,9 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/sliceutil"
-	v2command "github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
-	v2fileutil "github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/go-utils/v2/fileutil"
 	v2log "github.com/bitrise-io/go-utils/v2/log"
 	v2pathutil "github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-xcode/utility"
@@ -124,7 +124,7 @@ func (b XcodebuildBuild) ProcessConfig() (Config, error) {
 		}
 	}
 
-	factory := v2command.NewFactory(env.NewRepository())
+	factory := command.NewFactory(env.NewRepository())
 	xcodebuildVersion, err := utility.GetXcodeVersion()
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to get xcode version: %w", err)
@@ -268,7 +268,7 @@ func (b XcodebuildBuild) Run(cfg Config) (RunOut, error) {
 	xcodeBuildCmd.SetCustomOptions(cfg.XcodebuildOptions)
 
 	if cfg.XCConfig != "" {
-		xcconfigWriter := xcconfig.NewWriter(v2pathutil.NewPathProvider(), v2fileutil.NewFileManager(), v2pathutil.NewPathChecker(), v2pathutil.NewPathModifier())
+		xcconfigWriter := xcconfig.NewWriter(v2pathutil.NewPathProvider(), fileutil.NewFileManager(), v2pathutil.NewPathChecker(), v2pathutil.NewPathModifier())
 		xcconfigPath, err := xcconfigWriter.Write(cfg.XCConfig)
 		if err != nil {
 			return RunOut{}, err
@@ -350,8 +350,8 @@ func (b XcodebuildBuild) ExportOutputs(opts ExportOpts) error {
 
 	// Zipped test bundle
 	outputTestBundleZipPath := filepath.Join(opts.OutputDir, "testbundle.zip")
-	factory := v2command.NewFactory(env.NewRepository())
-	zipCmd := factory.Create("zip", []string{"-r", outputTestBundleZipPath, filepath.Base(opts.BuiltTestDir), filepath.Base(opts.XctestrunPth)}, &v2command.Opts{
+	factory := command.NewFactory(env.NewRepository())
+	zipCmd := factory.Create("zip", []string{"-r", outputTestBundleZipPath, filepath.Base(opts.BuiltTestDir), filepath.Base(opts.XctestrunPth)}, &command.Opts{
 		Dir: opts.SYMRoot,
 	})
 	if out, err := zipCmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
@@ -377,6 +377,7 @@ func (b XcodebuildBuild) ExportOutputs(opts ExportOpts) error {
 }
 
 func (b XcodebuildBuild) automaticCodeSigning(codesignManager *codesign.Manager) (*xcodebuild.AuthenticationParams, error) {
+	b.logger.Println()
 
 	if codesignManager == nil {
 		b.logger.Infof("Automatic code signing is disabled, skipped downloading code sign assets")

--- a/step/utils.go
+++ b/step/utils.go
@@ -1,4 +1,4 @@
-package main
+package step
 
 import (
 	"fmt"


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

This change won't be released in itself, but with an upcoming bug fix.

### Context

The intention of this PR is to prepare the Step for a bug fix around exporting outputs for Test Plan enabled projects.
To support this bug fix, this PR moves the Step functionality to the `step` package.
In the following PR(s) I will break some dependencies to make the Step and especially `XcodebuildBuild.ExportOutputs` testable.

### Changes

- Move `build.go`, `codesign.go`, `step.go` and `utils.go` to the `step` package.
- `step` package: `TestBuilder` rename to `XcodebuildBuild`.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
