### PR TITLE
Update bitrise.yml

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -258,7 +258,7 @@ workflows:
 
   _run_test_without_building:
     steps:
-    - git::https://github.com/bitrise-steplib/bitrise-step-xcode-test-without-building.git@step-init:
+    - xcode-test-without-building:
         inputs:
         - xctestrun: $BITRISE_XCTESTRUN_FILE_PATH
         - destination: $DESTINATION


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

This PR makes the e2e tests use `xcode-test-without-building` Step from the StepLib, rather than from a git url and a not existing branch.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- update `xcode-test-without-building` step reference in the e2e/bitrise.yml

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
