### PR TITLE
FIX exporting output variables for companion watchOS app targets

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -559,7 +559,7 @@ func (b XcodebuildBuilder) exportTestBundle(outputDir, symroot string, xctestrun
 	//	+ Debug-watchsimulator/
 	for _, builtTestsDir := range entries {
 		if builtTestsDir.IsDir() {
-			args = append(args, builtTestsDir)
+			args = append(args, builtTestsDir.Name())
 		}
 	}
 

--- a/step/step.go
+++ b/step/step.go
@@ -552,18 +552,17 @@ func (b XcodebuildBuilder) exportTestBundle(outputDir, symroot string, xctestrun
 		return fmt.Errorf("failed to list SYMROOT entries: %w", err)
 	}
 
-	var builtTestsDir string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			if builtTestsDir != "" {
-				return fmt.Errorf("multiple built test dir found in build output dir")
-			}
-			builtTestsDir = entry.Name()
+	args := []string{"-r", testBundleZipPth}
+
+	// add all build folders to zip file:
+	//	+ Debug-iphonesimulator/
+	//	+ Debug-watchsimulator/
+	for _, builtTestsDir := range entries {
+		if builtTestsDir.IsDir() {
+			args = append(args, builtTestsDir)
 		}
 	}
 
-	args := []string{"-r", testBundleZipPth}
-	args = append(args, builtTestsDir)
 	for _, xctestrunPth := range xctestrunPths {
 		args = append(args, filepath.Base(xctestrunPth))
 	}


### PR DESCRIPTION
This PR fixes the warning/error 

```
multiple built test dir found in build output dir
```

which will lead to the subsequent `xcode-test-without-building` step fail with following error:

```
failed to parse config:
- Xctestrun: required variable is not present
```

Because `xcode-build-for-test` step was unable to export the output variable `BITRISE_XCTESTRUN_FILE_PATH`.

![Screenshot 2022-11-02 at 15 45 37](https://user-images.githubusercontent.com/266349/199520668-6442d94a-3921-4f66-8534-d1cbeef88d3f.png)

Previously it was somehow expecting to only have one single folder in the output directory, while there can be multiple. But in fact, if a Xcode UI Test target testing an iOS app target that has a companion watch app, it will produce 2 folders instead of one (plus the usual .xctestrun file):

```
Build/Products:
|- Debug-iphonesimulator/
|- Debug-watchsimulator/
|- UITests_iphonesimulator15.5-arm64.xctestrun
```

![Screenshot 2022-11-02 at 15 54 02](https://user-images.githubusercontent.com/266349/199523073-f8a55f25-d37f-40ed-a95c-a12fcf11716c.png)


