### PR TITLE
[ACI-4110] Modify build dir path to be in the project home

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -223,7 +223,7 @@ workflows:
     - DESTINATION: generic/platform=iOS Simulator
     - DESTINATION_RUN_TEST: platform=iOS Simulator,name=iPhone 12 Pro Max
     - CODE_SIGNING_METHOD: "off"
-    - TEST_PLAN: UnitTests
+    - TEST_PLAN: FullTests
     steps:
     - bundle::cleanup_profiles: { }
     - bundle::run_step_test: { }

--- a/main.go
+++ b/main.go
@@ -54,8 +54,8 @@ func run() int {
 func createXcodebuildBuilder(logger log.Logger) step.XcodebuildBuilder {
 	xcproject := xcodeproject.NewXcodeProject()
 	pathChecker := pathutil.NewPathChecker()
-	pathProvider := pathutil.NewPathProvider()
+	pathModifier := pathutil.NewPathModifier()
 	fileManager := step.NewFileManager()
 
-	return step.NewXcodebuildBuilder(logger, xcproject, pathChecker, pathProvider, fileManager)
+	return step.NewXcodebuildBuilder(logger, xcproject, pathChecker, pathModifier, fileManager)
 }

--- a/step/step.go
+++ b/step/step.go
@@ -306,11 +306,11 @@ func (b XcodebuildBuilder) Run(cfg Config) (RunOut, error) {
 	symRoot := findBuildSetting(options, "SYMROOT")
 	if symRoot == "" {
 		symRoot, err = b.pathModifier.AbsPath("./test_bundle")
-		if err := os.MkdirAll(symRoot, 0755); err != nil {
-			return RunOut{}, fmt.Errorf("failed to create SYMROOT directory: %w", err)
-		}
 		if err != nil {
 			return RunOut{}, err
+		}
+		if err = os.MkdirAll(symRoot, 0755); err != nil {
+			return RunOut{}, fmt.Errorf("failed to create SYMROOT directory: %w", err)
 		}
 		options = append(options, fmt.Sprintf("SYMROOT=%s", symRoot))
 	}

--- a/step/step.go
+++ b/step/step.go
@@ -105,16 +105,16 @@ type XcodebuildBuilder struct {
 	logger       v2log.Logger
 	xcodeproject xcodeproject.XcodeProject
 	pathChecker  v2pathutil.PathChecker
-	pathProvider v2pathutil.PathProvider
+	pathModifier v2pathutil.PathModifier
 	fileManager  FileManager
 }
 
-func NewXcodebuildBuilder(logger v2log.Logger, xcodeproject xcodeproject.XcodeProject, pathChecker v2pathutil.PathChecker, pathProvider v2pathutil.PathProvider, fileManager FileManager) XcodebuildBuilder {
+func NewXcodebuildBuilder(logger v2log.Logger, xcodeproject xcodeproject.XcodeProject, pathChecker v2pathutil.PathChecker, pathModifier v2pathutil.PathModifier, fileManager FileManager) XcodebuildBuilder {
 	return XcodebuildBuilder{
 		logger:       logger,
 		xcodeproject: xcodeproject,
 		pathChecker:  pathChecker,
-		pathProvider: pathProvider,
+		pathModifier: pathModifier,
 		fileManager:  fileManager,
 	}
 }
@@ -305,7 +305,7 @@ func (b XcodebuildBuilder) Run(cfg Config) (RunOut, error) {
 	options := cfg.XcodebuildOptions
 	symRoot := findBuildSetting(options, "SYMROOT")
 	if symRoot == "" {
-		symRoot, err = b.pathProvider.CreateTempDir("test_bundle")
+		symRoot, err = b.pathModifier.AbsPath("./test_bundle")
 		if err != nil {
 			return RunOut{}, err
 		}

--- a/step/step.go
+++ b/step/step.go
@@ -306,6 +306,9 @@ func (b XcodebuildBuilder) Run(cfg Config) (RunOut, error) {
 	symRoot := findBuildSetting(options, "SYMROOT")
 	if symRoot == "" {
 		symRoot, err = b.pathModifier.AbsPath("./test_bundle")
+		if err := os.MkdirAll(symRoot, 0755); err != nil {
+			return RunOut{}, fmt.Errorf("failed to create SYMROOT directory: %w", err)
+		}
 		if err != nil {
 			return RunOut{}, err
 		}

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcscheme"
 	"github.com/bitrise-steplib/steps-xcode-build-for-test/mocks"
 	"github.com/stretchr/testify/mock"
@@ -95,7 +96,7 @@ type testingMocks struct {
 	logger       *mocks.Logger
 	xcodeproject *mocks.XcodeProject
 	pathChecker  *mocks.PathChecker
-	pathProvider *mocks.PathProvider
+	pathModifier *pathutil.PathModifier
 	fileManager  *mocks.FileManager
 }
 
@@ -103,16 +104,16 @@ func createStepAndMocks() (XcodebuildBuilder, testingMocks) {
 	logger := new(mocks.Logger)
 	xcodeproject := new(mocks.XcodeProject)
 	pathChecker := new(mocks.PathChecker)
-	pathProvider := new(mocks.PathProvider)
 	fileManager := new(mocks.FileManager)
+	pathModifier := pathutil.NewPathModifier()
 
-	step := NewXcodebuildBuilder(logger, xcodeproject, pathChecker, pathProvider, fileManager)
+	step := NewXcodebuildBuilder(logger, xcodeproject, pathChecker, pathModifier, fileManager)
 
 	mocks := testingMocks{
 		logger:       logger,
 		xcodeproject: xcodeproject,
 		pathChecker:  pathChecker,
-		pathProvider: pathProvider,
+		pathModifier: &pathModifier,
 		fileManager:  fileManager,
 	}
 


### PR DESCRIPTION
Compilation cache seems to be allergic to random temp path for now